### PR TITLE
feat: implement backtest trading system

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/sirily11/argo-trading-go
 go 1.24.0
 
 require (
-	github.com/alifiroozi80/duckdb v1.0.0
+	github.com/Masterminds/squirrel v1.5.4
+	github.com/go-playground/validator v9.31.0+incompatible
+	github.com/google/uuid v1.6.0
 	github.com/invopop/jsonschema v0.12.0
 	github.com/marcboeker/go-duckdb v1.8.5
 	github.com/moznion/go-optional v0.12.0
@@ -15,11 +17,9 @@ require (
 	go.uber.org/zap v1.27.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
-	gorm.io/gorm v1.25.12
 )
 
 require (
-	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/apache/arrow-go/v18 v18.2.0 // indirect
@@ -35,9 +35,6 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/google/flatbuffers v25.2.10+incompatible // indirect
-	github.com/google/uuid v1.6.0 // indirect
-	github.com/jinzhu/inflection v1.0.0 // indirect
-	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
@@ -63,4 +60,5 @@ require (
 	golang.org/x/text v0.24.0 // indirect
 	golang.org/x/tools v0.32.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
+	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1o
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
-github.com/alifiroozi80/duckdb v1.0.0 h1:VYpItAECu8zNCZF9fXAW4JkHkVntNMS9p4JcHFY9YAQ=
-github.com/alifiroozi80/duckdb v1.0.0/go.mod h1:fdZNpDXRbeNkjI6w6+RMHED2qNJP/V7x/RNbGG0p7W8=
 github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
 github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
 github.com/apache/arrow-go/v18 v18.2.0 h1:QhWqpgZMKfWOniGPhbUxrHohWnooGURqL2R2Gg4SO1Q=
@@ -31,6 +29,8 @@ github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/o
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
+github.com/go-playground/validator v9.31.0+incompatible h1:UA72EPEogEnq76ehGdEDp4Mit+3FDh548oRqwVgNsHA=
+github.com/go-playground/validator v9.31.0+incompatible/go.mod h1:yrEkQXlcI+PugkyDjY2bRrL/UBU4f3rvrgkN3V8JEig=
 github.com/go-playground/validator/v10 v10.23.0 h1:/PwmTwZhS0dPkav3cdK9kV1FsAmrL8sThn8IHr/sO+o=
 github.com/go-playground/validator/v10 v10.23.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/go-resty/resty/v2 v2.13.1 h1:x+LHXBI2nMB1vqndymf26quycC4aggYJ7DECYbiz03g=
@@ -51,10 +51,6 @@ github.com/invopop/jsonschema v0.12.0 h1:6ovsNSuvn9wEQVOyc72aycBMVQFKz7cPdMJn10C
 github.com/invopop/jsonschema v0.12.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=
 github.com/jarcoal/httpmock v1.3.1/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
-github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
-github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
-github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
-github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/klauspost/asmfmt v1.3.2 h1:4Ri7ox3EwapiOjCki+hw14RyKk201CN4rzyCJRFLpK4=
 github.com/klauspost/asmfmt v1.3.2/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j0HLHbNSE=
@@ -191,9 +187,9 @@ gonum.org/v1/gonum v0.15.1/go.mod h1:eZTZuRFrzu5pcyjN5wJhcIhnUdNijYxX1T2IcrOGY0o
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXadIrXTM=
+gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gorm.io/gorm v1.25.12 h1:I0u8i2hWQItBq1WfE0o2+WuL9+8L21K9e2HHSTE/0f8=
-gorm.io/gorm v1.25.12/go.mod h1:xh7N7RHfYlNc5EmcI/El95gXusucDrQnHXe0+CgWcLQ=

--- a/src/backtest/engine/engine_v1/backtest_trading.go
+++ b/src/backtest/engine/engine_v1/backtest_trading.go
@@ -1,0 +1,186 @@
+package engine
+
+import (
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/go-playground/validator"
+	"github.com/google/uuid"
+	"github.com/sirily11/argo-trading-go/src/backtest/engine/engine_v1/commission_fee"
+	"github.com/sirily11/argo-trading-go/src/trading"
+	"github.com/sirily11/argo-trading-go/src/types"
+	"github.com/sirily11/argo-trading-go/src/utils"
+)
+
+// BacktestTrading is a trading system that is used to backtest a trading strategy
+type BacktestTrading struct {
+	state         BacktestState
+	balance       float64
+	marketData    types.MarketData
+	pendingOrders []types.ExecuteOrder
+	commission    commission_fee.CommissionFee
+}
+
+func (b *BacktestTrading) UpdateCurrentMarketData(marketData types.MarketData) {
+	b.marketData = marketData
+}
+
+func (b *BacktestTrading) UpdateBalance(balance float64) {
+	b.balance = balance
+}
+
+// CancelAllOrders implements trading.TradingSystem.
+func (b *BacktestTrading) CancelAllOrders() error {
+	b.pendingOrders = []types.ExecuteOrder{}
+	return nil
+}
+
+// CancelOrder implements trading.TradingSystem.
+func (b *BacktestTrading) CancelOrder(orderID string) error {
+	for i, order := range b.pendingOrders {
+		if order.ID == orderID {
+			b.pendingOrders = slices.Delete(b.pendingOrders, i, i+1)
+			return nil
+		}
+	}
+	return nil
+}
+
+// GetOrderStatus implements trading.TradingSystem.
+func (b *BacktestTrading) GetOrderStatus(orderID string) (types.OrderStatus, error) {
+	order, err := b.state.GetOrderById(orderID)
+	if err != nil {
+		return types.OrderStatusFailed, err
+	}
+
+	if order.IsNone() {
+		return types.OrderStatusFailed, fmt.Errorf("order not found")
+	}
+
+	value, err := order.Take()
+	if err != nil {
+		return types.OrderStatusFailed, err
+	}
+
+	if value.IsCompleted {
+		return types.OrderStatusFilled, nil
+	}
+
+	// check if the order is in the pending orders
+	for _, pendingOrder := range b.pendingOrders {
+		if pendingOrder.ID == orderID {
+			return types.OrderStatusPending, nil
+		}
+	}
+	return types.OrderStatusFailed, nil
+}
+
+// GetPosition implements trading.TradingSystem.
+func (b *BacktestTrading) GetPosition(symbol string) (types.Position, error) {
+	position, err := b.state.GetPosition(symbol)
+	if err != nil {
+		return types.Position{}, err
+	}
+	return position, nil
+}
+
+// GetPositions implements trading.TradingSystem.
+func (b *BacktestTrading) GetPositions() ([]types.Position, error) {
+	positions, err := b.state.GetAllPositions()
+	if err != nil {
+		return []types.Position{}, err
+	}
+	return positions, nil
+}
+
+// PlaceMultipleOrders implements trading.TradingSystem.
+func (b *BacktestTrading) PlaceMultipleOrders(orders []types.ExecuteOrder) error {
+	for _, order := range orders {
+		err := b.PlaceOrder(order)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// PlaceOrder implements trading.TradingSystem.
+func (b *BacktestTrading) PlaceOrder(order types.ExecuteOrder) error {
+	// validate the order using go-playground/validator/v10
+	order.ID = uuid.New().String()
+	validate := validator.New()
+	err := validate.Struct(order)
+	if err != nil {
+		return err
+	}
+
+	// check if the order's price is within the price range
+	if order.Price < b.marketData.Low {
+		return fmt.Errorf("order price is out of range")
+	}
+
+	// check if the order's price is above the range
+	executePrice := order.Price
+	if order.Price > b.marketData.High {
+		executePrice = b.marketData.High
+	}
+	if executePrice <= 0 {
+		return fmt.Errorf("order price is out of range: %f", executePrice)
+	}
+
+	// check if the order's quantity is less than the current buying power
+	if order.Side == types.PurchaseTypeBuy {
+		buyingPower := b.getBuyingPower()
+		if order.Quantity > buyingPower {
+			return fmt.Errorf("order quantity is greater than the current buying power")
+		}
+	} else {
+		sellingPower := b.getSellingPower()
+		if order.Quantity > sellingPower {
+			return fmt.Errorf("order quantity is greater than the current selling power")
+		}
+	}
+	// create the order
+	commission := b.commission.Calculate(order.Quantity)
+	executedOrder := types.Order{
+		Symbol:       order.Symbol,
+		Side:         order.Side,
+		Quantity:     order.Quantity,
+		Price:        executePrice,
+		Timestamp:    time.Now(),
+		IsCompleted:  false,
+		Reason:       order.Reason,
+		StrategyName: order.StrategyName,
+		Fee:          commission,
+	}
+	// place the order
+	_, err = b.state.Update([]types.Order{executedOrder})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *BacktestTrading) getBuyingPower() float64 {
+	return float64(utils.CalculateMaxQuantity(b.balance, (b.marketData.High+b.marketData.Low)/2, b.commission))
+}
+
+func (b *BacktestTrading) getSellingPower() float64 {
+	// get current position
+	position, err := b.GetPosition(b.marketData.Symbol)
+	if err != nil {
+		return 0
+	}
+	return position.Quantity
+}
+
+func NewBacktestTrading(state BacktestState, initialBalance float64, commission commission_fee.CommissionFee) trading.TradingSystem {
+	return &BacktestTrading{
+		state:         state,
+		balance:       initialBalance,
+		marketData:    types.MarketData{},
+		pendingOrders: []types.ExecuteOrder{},
+		commission:    commission,
+	}
+}

--- a/src/backtest/engine/engine_v1/backtest_trading_test.go
+++ b/src/backtest/engine/engine_v1/backtest_trading_test.go
@@ -1,0 +1,418 @@
+package engine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sirily11/argo-trading-go/src/backtest/engine/engine_v1/commission_fee"
+	"github.com/sirily11/argo-trading-go/src/logger"
+	"github.com/sirily11/argo-trading-go/src/types"
+	"github.com/stretchr/testify/suite"
+)
+
+// BacktestTradingTestSuite is a test suite for BacktestTrading
+type BacktestTradingTestSuite struct {
+	suite.Suite
+	state          *BacktestState
+	logger         *logger.Logger
+	trading        *BacktestTrading
+	commission     commission_fee.CommissionFee
+	initialBalance float64
+}
+
+// SetupSuite runs once before all tests in the suite
+func (suite *BacktestTradingTestSuite) SetupSuite() {
+	logger, err := logger.NewLogger()
+	suite.Require().NoError(err)
+	suite.logger = logger
+	suite.state = NewBacktestState(suite.logger)
+	suite.Require().NotNil(suite.state)
+	suite.initialBalance = 10000.0
+	suite.commission = commission_fee.NewZeroCommissionFee()
+}
+
+// TearDownSuite runs once after all tests in the suite
+func (suite *BacktestTradingTestSuite) TearDownSuite() {
+	if suite.state != nil && suite.state.db != nil {
+		suite.state.db.Close()
+	}
+}
+
+// SetupTest runs before each test
+func (suite *BacktestTradingTestSuite) SetupTest() {
+	err := suite.state.Initialize()
+	suite.Require().NoError(err)
+	suite.trading = &BacktestTrading{
+		state:         *suite.state,
+		balance:       suite.initialBalance,
+		marketData:    types.MarketData{},
+		pendingOrders: []types.ExecuteOrder{},
+		commission:    suite.commission,
+	}
+}
+
+// TearDownTest runs after each test
+func (suite *BacktestTradingTestSuite) TearDownTest() {
+	err := suite.state.Cleanup()
+	suite.Require().NoError(err)
+}
+
+// TestBacktestTradingTestSuite runs the test suite
+func TestBacktestTradingTestSuite(t *testing.T) {
+	suite.Run(t, new(BacktestTradingTestSuite))
+}
+
+func (suite *BacktestTradingTestSuite) TestUpdateCurrentMarketData() {
+	marketData := types.MarketData{
+		Symbol: "AAPL",
+		High:   100.0,
+		Low:    90.0,
+		Close:  95.0,
+	}
+
+	suite.trading.UpdateCurrentMarketData(marketData)
+	suite.Assert().Equal(marketData, suite.trading.marketData)
+}
+
+func (suite *BacktestTradingTestSuite) TestCancelAllOrders() {
+	// Setup test data
+	suite.trading.pendingOrders = []types.ExecuteOrder{
+		{
+			ID:     "order1",
+			Symbol: "AAPL",
+		},
+		{
+			ID:     "order2",
+			Symbol: "GOOGL",
+		},
+	}
+
+	err := suite.trading.CancelAllOrders()
+	suite.Require().NoError(err)
+	suite.Assert().Empty(suite.trading.pendingOrders)
+}
+
+func (suite *BacktestTradingTestSuite) TestCancelOrder() {
+	// Setup test data
+	suite.trading.pendingOrders = []types.ExecuteOrder{
+		{
+			ID:     "order1",
+			Symbol: "AAPL",
+		},
+		{
+			ID:     "order2",
+			Symbol: "GOOGL",
+		},
+	}
+
+	// Test canceling existing order
+	err := suite.trading.CancelOrder("order1")
+	suite.Require().NoError(err)
+	suite.Assert().Len(suite.trading.pendingOrders, 1)
+	suite.Assert().Equal("order2", suite.trading.pendingOrders[0].ID)
+
+	// Test canceling non-existent order
+	err = suite.trading.CancelOrder("non-existent")
+	suite.Require().NoError(err)
+	suite.Assert().Len(suite.trading.pendingOrders, 1)
+}
+
+func (suite *BacktestTradingTestSuite) TestPlaceOrder() {
+	tests := []struct {
+		name        string
+		marketData  types.MarketData
+		order       types.ExecuteOrder
+		expectError bool
+	}{
+		{
+			name: "Valid order within price range",
+			marketData: types.MarketData{
+				Symbol: "AAPL",
+				High:   100.0,
+				Low:    90.0,
+			},
+			order: types.ExecuteOrder{
+				Symbol:       "AAPL",
+				Side:         types.PurchaseTypeBuy,
+				OrderType:    types.OrderTypeLimit,
+				Quantity:     10,
+				Price:        95.0,
+				StrategyName: "test_strategy",
+				Reason: types.Reason{
+					Reason: "test",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "Order price above range",
+			marketData: types.MarketData{
+				Symbol: "AAPL",
+				High:   100.0,
+				Low:    90.0,
+			},
+			order: types.ExecuteOrder{
+				Symbol:       "AAPL",
+				Side:         types.PurchaseTypeBuy,
+				OrderType:    types.OrderTypeLimit,
+				Quantity:     10,
+				Price:        110.0,
+				StrategyName: "test_strategy",
+				Reason: types.Reason{
+					Reason: "test",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "Order price below range",
+			marketData: types.MarketData{
+				Symbol: "AAPL",
+				High:   100.0,
+				Low:    90.0,
+			},
+			order: types.ExecuteOrder{
+				Symbol:       "AAPL",
+				Side:         types.PurchaseTypeBuy,
+				OrderType:    types.OrderTypeLimit,
+				Quantity:     10,
+				Price:        85.0,
+				StrategyName: "test_strategy",
+				Reason: types.Reason{
+					Reason: "test",
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "Order quantity exceeds buying power",
+			marketData: types.MarketData{
+				Symbol: "AAPL",
+				High:   100.0,
+				Low:    90.0,
+			},
+			order: types.ExecuteOrder{
+				Symbol:       "AAPL",
+				Side:         types.PurchaseTypeBuy,
+				OrderType:    types.OrderTypeLimit,
+				Quantity:     1000000, // Very large quantity
+				Price:        95.0,
+				StrategyName: "test_strategy",
+				Reason: types.Reason{
+					Reason: "test",
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "Order quantity exceeds selling power",
+			marketData: types.MarketData{
+				Symbol: "AAPL",
+				High:   100.0,
+				Low:    90.0,
+			},
+			order: types.ExecuteOrder{
+				Symbol:       "AAPL",
+				Side:         types.PurchaseTypeSell,
+				OrderType:    types.OrderTypeLimit,
+				Quantity:     1000, // Selling more than held
+				Price:        95.0,
+				StrategyName: "test_strategy",
+				Reason: types.Reason{
+					Reason: "test",
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			suite.trading.UpdateCurrentMarketData(tc.marketData)
+			err := suite.trading.PlaceOrder(tc.order)
+			if tc.expectError {
+				suite.Assert().Error(err)
+			} else {
+				suite.Assert().NoError(err)
+			}
+		})
+	}
+}
+
+func (suite *BacktestTradingTestSuite) TestPlaceMultipleOrders() {
+	marketData := types.MarketData{
+		Symbol: "AAPL",
+		High:   100.0,
+		Low:    90.0,
+	}
+	suite.trading.UpdateCurrentMarketData(marketData)
+
+	orders := []types.ExecuteOrder{
+		{
+			Symbol:       "AAPL",
+			Side:         types.PurchaseTypeBuy,
+			OrderType:    types.OrderTypeLimit,
+			Quantity:     10,
+			Price:        95.0,
+			StrategyName: "test_strategy",
+			Reason: types.Reason{
+				Reason: "test",
+			},
+		},
+		{
+			Symbol:       "AAPL",
+			Side:         types.PurchaseTypeBuy,
+			OrderType:    types.OrderTypeLimit,
+			Quantity:     5,
+			Price:        93.0,
+			StrategyName: "test_strategy",
+			Reason: types.Reason{
+				Reason: "test",
+			},
+		},
+	}
+
+	err := suite.trading.PlaceMultipleOrders(orders)
+	suite.Require().NoError(err)
+
+	// Test with invalid order
+	invalidOrders := append(orders, types.ExecuteOrder{
+		Symbol:       "AAPL",
+		Side:         types.PurchaseTypeBuy,
+		OrderType:    types.OrderTypeLimit,
+		Quantity:     1000000, // Very large quantity
+		Price:        95.0,
+		StrategyName: "test_strategy",
+	})
+	err = suite.trading.PlaceMultipleOrders(invalidOrders)
+	suite.Assert().Error(err)
+}
+
+func (suite *BacktestTradingTestSuite) TestGetOrderStatus() {
+	// Setup test data
+	completedOrder := types.Order{
+		OrderID:      "completed",
+		Symbol:       "AAPL",
+		IsCompleted:  true,
+		StrategyName: "test_strategy",
+	}
+	result, err := suite.state.Update([]types.Order{completedOrder})
+	suite.Require().NoError(err)
+	completedOrder.OrderID = result[0].Order.OrderID
+	// should not test pending order here
+	// Add the pending order to the trading system's pending orders
+	suite.trading.pendingOrders = []types.ExecuteOrder{
+		{
+			ID:           "pending",
+			Symbol:       "GOOGL",
+			StrategyName: "test_strategy",
+		},
+	}
+
+	tests := []struct {
+		name           string
+		orderID        string
+		expectedStatus types.OrderStatus
+		expectError    bool
+	}{
+		{
+			name:           "Completed order",
+			orderID:        completedOrder.OrderID,
+			expectedStatus: types.OrderStatusFilled,
+			expectError:    false,
+		},
+		{
+			name:           "Non-existent order",
+			orderID:        "non-existent",
+			expectedStatus: types.OrderStatusFailed,
+			expectError:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			status, err := suite.trading.GetOrderStatus(tc.orderID)
+			if tc.expectError {
+				suite.Assert().Error(err)
+			} else {
+				suite.Assert().NoError(err)
+				suite.Assert().Equal(tc.expectedStatus, status)
+			}
+		})
+	}
+}
+
+func (suite *BacktestTradingTestSuite) TestGetPosition() {
+	// Setup test data
+	order := types.Order{
+		Symbol:       "AAPL",
+		Side:         types.PurchaseTypeBuy,
+		Quantity:     100,
+		Price:        100.0,
+		Timestamp:    time.Now(),
+		IsCompleted:  true,
+		StrategyName: "test_strategy",
+	}
+	_, err := suite.state.Update([]types.Order{order})
+	suite.Require().NoError(err)
+
+	// Test getting existing position
+	position, err := suite.trading.GetPosition("AAPL")
+	suite.Require().NoError(err)
+	suite.Assert().Equal("AAPL", position.Symbol)
+	suite.Assert().Equal(float64(100), position.Quantity)
+
+	// Test getting non-existent position
+	position, err = suite.trading.GetPosition("GOOGL")
+	suite.Require().NoError(err)
+	suite.Assert().Equal("GOOGL", position.Symbol)
+	suite.Assert().Equal(float64(0), position.Quantity)
+}
+
+func (suite *BacktestTradingTestSuite) TestGetPositions() {
+	// Setup test data with unique order IDs
+	orders := []types.Order{
+		{
+			OrderID:      "order1",
+			Symbol:       "AAPL",
+			Side:         types.PurchaseTypeBuy,
+			Quantity:     100,
+			Price:        100.0,
+			Timestamp:    time.Now(),
+			IsCompleted:  true,
+			StrategyName: "test_strategy",
+		},
+		{
+			OrderID:      "order2",
+			Symbol:       "GOOGL",
+			Side:         types.PurchaseTypeBuy,
+			Quantity:     50,
+			Price:        2000.0,
+			Timestamp:    time.Now(),
+			IsCompleted:  true,
+			StrategyName: "test_strategy",
+		},
+	}
+
+	// Update state with each order individually to avoid batch issues
+	for _, order := range orders {
+		_, err := suite.state.Update([]types.Order{order})
+		suite.Require().NoError(err)
+	}
+
+	positions, err := suite.trading.GetPositions()
+	suite.Require().NoError(err)
+	suite.Assert().Len(positions, 2)
+
+	// Verify positions
+	for _, position := range positions {
+		switch position.Symbol {
+		case "AAPL":
+			suite.Assert().Equal(float64(100), position.Quantity)
+		case "GOOGL":
+			suite.Assert().Equal(float64(50), position.Quantity)
+		default:
+			suite.Fail("Unexpected position symbol")
+		}
+	}
+}

--- a/src/backtest/engine/engine_v1/cache/cache.go
+++ b/src/backtest/engine/engine_v1/cache/cache.go
@@ -19,15 +19,27 @@ type RangeFilterState struct {
 
 type CacheV1 struct {
 	RangeFilterState optional.Option[RangeFilterState]
+	otherData        map[string]any
 }
 
 func NewCacheV1() Cache {
 	return &CacheV1{
 		RangeFilterState: optional.None[RangeFilterState](),
+		otherData:        make(map[string]any),
 	}
 }
 
 // Reset implements cache.Cache.
 func (c *CacheV1) Reset() {
 	c.RangeFilterState = optional.None[RangeFilterState]()
+	c.otherData = make(map[string]any)
+}
+
+func (c *CacheV1) Set(key string, value any) {
+	c.otherData[key] = value
+}
+
+func (c *CacheV1) Get(key string) (any, bool) {
+	value, ok := c.otherData[key]
+	return value, ok
 }

--- a/src/backtest/engine/engine_v1/cache/cache_test.go
+++ b/src/backtest/engine/engine_v1/cache/cache_test.go
@@ -1,0 +1,94 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/moznion/go-optional"
+	"github.com/stretchr/testify/suite"
+)
+
+// CacheTestSuite is a test suite for CacheV1
+type CacheTestSuite struct {
+	suite.Suite
+	cache *CacheV1
+}
+
+// SetupTest runs before each test
+func (suite *CacheTestSuite) SetupTest() {
+	suite.cache = NewCacheV1().(*CacheV1)
+}
+
+// TestCacheSuite runs the test suite
+func TestCacheSuite(t *testing.T) {
+	suite.Run(t, new(CacheTestSuite))
+}
+
+// TestNewCacheV1 tests the creation of a new CacheV1 instance
+func (suite *CacheTestSuite) TestNewCacheV1() {
+	cache := NewCacheV1()
+	suite.Require().NotNil(cache)
+	suite.IsType(&CacheV1{}, cache)
+}
+
+// TestReset tests the Reset functionality
+func (suite *CacheTestSuite) TestReset() {
+	// Set some initial state
+	initialState := RangeFilterState{
+		Initialized: true,
+		PrevFilt:    100.0,
+		PrevSource:  100.0,
+		Upward:      1.0,
+		Downward:    1.0,
+		Symbol:      "BTCUSDT",
+	}
+	suite.cache.RangeFilterState = optional.Some(initialState)
+	suite.cache.otherData = map[string]any{
+		"test": "value",
+	}
+
+	// Reset the cache
+	suite.cache.Reset()
+
+	// Verify the cache is reset
+	suite.True(suite.cache.RangeFilterState.IsNone())
+	suite.Empty(suite.cache.otherData)
+}
+
+// TestSetAndGet tests the Set and Get functionality
+func (suite *CacheTestSuite) TestSetAndGet() {
+	// Test setting and getting a value
+	key := "testKey"
+	value := "testValue"
+	suite.cache.Set(key, value)
+
+	// Verify the value can be retrieved
+	retrievedValue, exists := suite.cache.Get(key)
+	suite.True(exists)
+	suite.Equal(value, retrievedValue)
+
+	// Test getting a non-existent key
+	_, exists = suite.cache.Get("nonExistentKey")
+	suite.False(exists)
+}
+
+// TestRangeFilterState tests the RangeFilterState functionality
+func (suite *CacheTestSuite) TestRangeFilterState() {
+	// Test initial state is None
+	suite.True(suite.cache.RangeFilterState.IsNone())
+
+	// Test setting RangeFilterState
+	state := RangeFilterState{
+		Initialized: true,
+		PrevFilt:    100.0,
+		PrevSource:  100.0,
+		Upward:      1.0,
+		Downward:    1.0,
+		Symbol:      "BTCUSDT",
+	}
+	suite.cache.RangeFilterState = optional.Some(state)
+
+	// Verify the state is set correctly
+	suite.True(suite.cache.RangeFilterState.IsSome())
+	retrievedState := suite.cache.RangeFilterState.Unwrap()
+	suite.Equal(state, retrievedState)
+}

--- a/src/backtest/engine/engine_v1/state_test.go
+++ b/src/backtest/engine/engine_v1/state_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/moznion/go-optional"
 	"github.com/sirily11/argo-trading-go/src/backtest/engine/engine_v1/datasource"
 	"github.com/sirily11/argo-trading-go/src/logger"
@@ -75,6 +76,7 @@ func (suite *BacktestStateTestSuite) TestUpdate() {
 			name: "Single entry with fee",
 			orders: []types.Order{
 				{
+					OrderID:     "order1",
 					Symbol:      "AAPL",
 					Side:        types.PurchaseTypeBuy,
 					Quantity:    100,
@@ -89,6 +91,18 @@ func (suite *BacktestStateTestSuite) TestUpdate() {
 			},
 			expectedTrades: []types.Trade{
 				{
+					Order: types.Order{
+						OrderID:     "order1",
+						Symbol:      "AAPL",
+						Side:        types.PurchaseTypeBuy,
+						Quantity:    100,
+						Price:       100.0,
+						Timestamp:   time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+						IsCompleted: true,
+						Reason: types.Reason{
+							Reason: "test",
+						},
+					},
 					ExecutedAt:    time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
 					ExecutedQty:   100,
 					ExecutedPrice: 100.0,
@@ -109,6 +123,7 @@ func (suite *BacktestStateTestSuite) TestUpdate() {
 			name: "Single entry and exit with fee",
 			orders: []types.Order{
 				{
+					OrderID:     "order1",
 					Symbol:      "AAPL",
 					Side:        types.PurchaseTypeBuy,
 					Quantity:    100,
@@ -121,6 +136,7 @@ func (suite *BacktestStateTestSuite) TestUpdate() {
 					},
 				},
 				{
+					OrderID:     "order2",
 					Symbol:      "AAPL",
 					Side:        types.PurchaseTypeSell,
 					Quantity:    100,
@@ -135,6 +151,18 @@ func (suite *BacktestStateTestSuite) TestUpdate() {
 			},
 			expectedTrades: []types.Trade{
 				{
+					Order: types.Order{
+						OrderID:     "order1",
+						Symbol:      "AAPL",
+						Side:        types.PurchaseTypeBuy,
+						Quantity:    100,
+						Price:       100.0,
+						Timestamp:   time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+						IsCompleted: true,
+						Reason: types.Reason{
+							Reason: "test",
+						},
+					},
 					ExecutedAt:    time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
 					ExecutedQty:   100,
 					ExecutedPrice: 100.0,
@@ -142,6 +170,18 @@ func (suite *BacktestStateTestSuite) TestUpdate() {
 					PnL:           0,
 				},
 				{
+					Order: types.Order{
+						OrderID:     "order2",
+						Symbol:      "AAPL",
+						Side:        types.PurchaseTypeSell,
+						Quantity:    100,
+						Price:       110.0,
+						Timestamp:   time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+						IsCompleted: true,
+						Reason: types.Reason{
+							Reason: "test",
+						},
+					},
 					ExecutedAt:    time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
 					ExecutedQty:   100,
 					ExecutedPrice: 110.0,
@@ -162,6 +202,7 @@ func (suite *BacktestStateTestSuite) TestUpdate() {
 			name: "Single entry and partial close with fee",
 			orders: []types.Order{
 				{
+					OrderID:     "order1",
 					Symbol:      "AAPL",
 					Side:        types.PurchaseTypeBuy,
 					Quantity:    100,
@@ -174,6 +215,7 @@ func (suite *BacktestStateTestSuite) TestUpdate() {
 					},
 				},
 				{
+					OrderID:   "order2",
 					Symbol:    "AAPL",
 					Side:      types.PurchaseTypeSell,
 					Quantity:  50,
@@ -184,6 +226,18 @@ func (suite *BacktestStateTestSuite) TestUpdate() {
 			},
 			expectedTrades: []types.Trade{
 				{
+					Order: types.Order{
+						OrderID:     "order1",
+						Symbol:      "AAPL",
+						Side:        types.PurchaseTypeBuy,
+						Quantity:    100,
+						Price:       100.0,
+						Timestamp:   time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+						IsCompleted: true,
+						Reason: types.Reason{
+							Reason: "test",
+						},
+					},
 					ExecutedAt:    time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
 					ExecutedQty:   100,
 					ExecutedPrice: 100.0,
@@ -191,6 +245,18 @@ func (suite *BacktestStateTestSuite) TestUpdate() {
 					PnL:           0,
 				},
 				{
+					Order: types.Order{
+						OrderID:     "order2",
+						Symbol:      "AAPL",
+						Side:        types.PurchaseTypeSell,
+						Quantity:    50,
+						Price:       110.0,
+						Timestamp:   time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+						IsCompleted: true,
+						Reason: types.Reason{
+							Reason: "test",
+						},
+					},
 					ExecutedAt:    time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
 					ExecutedQty:   50,
 					ExecutedPrice: 110.0,
@@ -212,6 +278,7 @@ func (suite *BacktestStateTestSuite) TestUpdate() {
 			name: "Multiple entry and close long position with fee",
 			orders: []types.Order{
 				{
+					OrderID:     "order1",
 					Symbol:      "AAPL",
 					Side:        types.PurchaseTypeBuy,
 					Quantity:    100,
@@ -226,6 +293,7 @@ func (suite *BacktestStateTestSuite) TestUpdate() {
 					Fee:          1.0,
 				},
 				{
+					OrderID:     "order2",
 					Symbol:      "AAPL",
 					Side:        types.PurchaseTypeBuy,
 					Quantity:    100,
@@ -240,6 +308,7 @@ func (suite *BacktestStateTestSuite) TestUpdate() {
 					Fee:          1.0,
 				},
 				{
+					OrderID:     "order3",
 					Symbol:      "AAPL",
 					Side:        types.PurchaseTypeBuy,
 					Quantity:    100,
@@ -254,6 +323,7 @@ func (suite *BacktestStateTestSuite) TestUpdate() {
 					Fee:          1.0,
 				},
 				{
+					OrderID:     "order4",
 					Symbol:      "AAPL",
 					Side:        types.PurchaseTypeSell,
 					Quantity:    100,
@@ -268,6 +338,7 @@ func (suite *BacktestStateTestSuite) TestUpdate() {
 					Fee:          1.0,
 				},
 				{
+					OrderID:     "order5",
 					Symbol:      "AAPL",
 					Side:        types.PurchaseTypeSell,
 					Quantity:    100,
@@ -282,6 +353,7 @@ func (suite *BacktestStateTestSuite) TestUpdate() {
 					Fee:          1.0,
 				},
 				{
+					OrderID:     "order6",
 					Symbol:      "AAPL",
 					Side:        types.PurchaseTypeSell,
 					Quantity:    100,
@@ -298,6 +370,18 @@ func (suite *BacktestStateTestSuite) TestUpdate() {
 			},
 			expectedTrades: []types.Trade{
 				{
+					Order: types.Order{
+						OrderID:     "order1",
+						Symbol:      "AAPL",
+						Side:        types.PurchaseTypeBuy,
+						Quantity:    100,
+						Price:       100.0,
+						Timestamp:   time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+						IsCompleted: true,
+						Reason: types.Reason{
+							Reason: "test",
+						},
+					},
 					ExecutedAt:    time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
 					ExecutedQty:   100,
 					ExecutedPrice: 100.0,
@@ -305,6 +389,18 @@ func (suite *BacktestStateTestSuite) TestUpdate() {
 					PnL:           0,
 				},
 				{
+					Order: types.Order{
+						OrderID:     "order2",
+						Symbol:      "AAPL",
+						Side:        types.PurchaseTypeBuy,
+						Quantity:    100,
+						Price:       90.0,
+						Timestamp:   time.Date(2024, 1, 1, 11, 0, 0, 0, time.UTC),
+						IsCompleted: true,
+						Reason: types.Reason{
+							Reason: "test",
+						},
+					},
 					ExecutedAt:    time.Date(2024, 1, 1, 11, 0, 0, 0, time.UTC),
 					ExecutedQty:   100,
 					ExecutedPrice: 90.0,
@@ -312,6 +408,18 @@ func (suite *BacktestStateTestSuite) TestUpdate() {
 					PnL:           0,
 				},
 				{
+					Order: types.Order{
+						OrderID:     "order3",
+						Symbol:      "AAPL",
+						Side:        types.PurchaseTypeBuy,
+						Quantity:    100,
+						Price:       80.0,
+						Timestamp:   time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+						IsCompleted: true,
+						Reason: types.Reason{
+							Reason: "test",
+						},
+					},
 					ExecutedAt:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
 					ExecutedQty:   100,
 					ExecutedPrice: 80.0,
@@ -319,28 +427,61 @@ func (suite *BacktestStateTestSuite) TestUpdate() {
 					PnL:           0,
 				},
 				{
+					Order: types.Order{
+						OrderID:     "order4",
+						Symbol:      "AAPL",
+						Side:        types.PurchaseTypeSell,
+						Quantity:    100,
+						Price:       110.0,
+						Timestamp:   time.Date(2024, 1, 1, 13, 0, 0, 0, time.UTC),
+						IsCompleted: true,
+						Reason: types.Reason{
+							Reason: "test",
+						},
+					},
 					ExecutedAt:    time.Date(2024, 1, 1, 13, 0, 0, 0, time.UTC),
 					ExecutedQty:   100,
 					ExecutedPrice: 110.0,
 					Fee:           1.0,
-					// ((110*100-1)/100 - (100*100+1 + 90*100+1 + 80*100+1)/300) * 100
-					PnL: 1998,
+					PnL:           1998,
 				},
 				{
+					Order: types.Order{
+						OrderID:     "order5",
+						Symbol:      "AAPL",
+						Side:        types.PurchaseTypeSell,
+						Quantity:    100,
+						Price:       120.0,
+						Timestamp:   time.Date(2024, 1, 1, 14, 0, 0, 0, time.UTC),
+						IsCompleted: true,
+						Reason: types.Reason{
+							Reason: "test",
+						},
+					},
 					ExecutedAt:    time.Date(2024, 1, 1, 14, 0, 0, 0, time.UTC),
 					ExecutedQty:   100,
 					ExecutedPrice: 120.0,
 					Fee:           1.0,
-					//  ((120*100-1)/100 - (100*100+1 + 90*100+1 + 80*100+1)/300) * 100
-					PnL: 2998,
+					PnL:           2998,
 				},
 				{
+					Order: types.Order{
+						OrderID:     "order6",
+						Symbol:      "AAPL",
+						Side:        types.PurchaseTypeSell,
+						Quantity:    100,
+						Price:       130.0,
+						Timestamp:   time.Date(2024, 1, 1, 15, 0, 0, 0, time.UTC),
+						IsCompleted: true,
+						Reason: types.Reason{
+							Reason: "test",
+						},
+					},
 					ExecutedAt:    time.Date(2024, 1, 1, 15, 0, 0, 0, time.UTC),
 					ExecutedQty:   100,
 					ExecutedPrice: 130.0,
 					Fee:           1.0,
-					// ((130*100-1)/100 -  (100*100+1 + 90*100+1 + 80*100+1)/300) * 100
-					PnL: 3998,
+					PnL:           3998,
 				},
 			},
 			expectedPosition: ExpectPosition{
@@ -436,6 +577,7 @@ func (suite *BacktestStateTestSuite) TestWrite() {
 	// Create some test data
 	orders := []types.Order{
 		{
+			OrderID:     "order1",
 			Symbol:      "AAPL",
 			Side:        types.PurchaseTypeBuy,
 			Quantity:    100,
@@ -449,6 +591,7 @@ func (suite *BacktestStateTestSuite) TestWrite() {
 			StrategyName: "test_strategy",
 		},
 		{
+			OrderID:     "order2",
 			Symbol:      "AAPL",
 			Side:        types.PurchaseTypeSell,
 			Quantity:    50,
@@ -586,6 +729,7 @@ func (suite *BacktestStateTestSuite) TestGetStats() {
 			name: "Single symbol with multiple trades",
 			orders: []types.Order{
 				{
+					OrderID:     "order1",
 					Symbol:      "AAPL",
 					Side:        types.PurchaseTypeBuy,
 					Quantity:    100,
@@ -598,6 +742,7 @@ func (suite *BacktestStateTestSuite) TestGetStats() {
 					},
 				},
 				{
+					OrderID:     "order2",
 					Symbol:      "AAPL",
 					Side:        types.PurchaseTypeSell,
 					Quantity:    50,
@@ -641,6 +786,7 @@ func (suite *BacktestStateTestSuite) TestGetStats() {
 			name: "Multiple symbols with trades",
 			orders: []types.Order{
 				{
+					OrderID:     "order1",
 					Symbol:      "AAPL",
 					Side:        types.PurchaseTypeBuy,
 					Quantity:    100,
@@ -653,6 +799,7 @@ func (suite *BacktestStateTestSuite) TestGetStats() {
 					},
 				},
 				{
+					OrderID:     "order2",
 					Symbol:      "GOOGL",
 					Side:        types.PurchaseTypeBuy,
 					Quantity:    50,
@@ -769,6 +916,504 @@ func (suite *BacktestStateTestSuite) TestGetStats() {
 				suite.Assert().Equal(expected.TradeHoldingTime.Max, actual.TradeHoldingTime.Max, "Max holding time mismatch")
 				suite.Assert().Equal(expected.TradeHoldingTime.Avg, actual.TradeHoldingTime.Avg, "Avg holding time mismatch")
 			}
+		})
+	}
+}
+
+func (suite *BacktestStateTestSuite) TestGetOrderById() {
+
+	tests := []struct {
+		name        string
+		orders      []types.Order
+		expected    optional.Option[types.Order]
+		expectError bool
+		isExisting  bool
+	}{
+		{
+			name: "Existing order",
+			orders: []types.Order{
+				{
+					Symbol:      "AAPL",
+					Side:        types.PurchaseTypeBuy,
+					Quantity:    100,
+					Price:       100.0,
+					Timestamp:   time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+					IsCompleted: true,
+					Reason: types.Reason{
+						Reason:  "test",
+						Message: "test message",
+					},
+					StrategyName: "test_strategy",
+				},
+			},
+			isExisting:  true,
+			expectError: false,
+		},
+		{
+			name: "Non-existing order",
+			orders: []types.Order{
+				{
+					Symbol:      "AAPL",
+					Side:        types.PurchaseTypeBuy,
+					Quantity:    100,
+					Price:       100.0,
+					Timestamp:   time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+					IsCompleted: true,
+					Reason: types.Reason{
+						Reason:  "test",
+						Message: "test message",
+					},
+					StrategyName: "test_strategy",
+				},
+			},
+			expectError: false,
+			isExisting:  false,
+		},
+	}
+
+	existingOrderID := ""
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			// Reset state before each test case
+			err := suite.state.Cleanup()
+			suite.Require().NoError(err)
+
+			// Process orders and store generated order IDs
+			for _, order := range tc.orders {
+				results, err := suite.state.Update([]types.Order{order})
+				existingOrderID = results[0].Order.OrderID
+				suite.Require().NoError(err)
+				suite.Require().Len(results, 1)
+			}
+
+			// For the first test case, we'll look up the existing order
+			// For the second test case, we'll look up a non-existent order
+			var orderID string
+			if tc.isExisting {
+				orderID = existingOrderID
+			} else {
+				orderID = uuid.New().String()
+			}
+
+			// Get order by ID
+			result, err := suite.state.GetOrderById(orderID)
+			if tc.expectError {
+				suite.Assert().Error(err)
+				return
+			}
+
+			suite.Assert().NoError(err)
+
+			if tc.name == "Existing order" {
+				suite.Assert().True(result.IsSome(), "Expected order to exist")
+				actualOrder := result.Unwrap()
+
+				// Verify the order details match the input order (except for the generated ID)
+				suite.Assert().Equal(tc.orders[0].Symbol, actualOrder.Symbol, "Symbol mismatch")
+				suite.Assert().Equal(tc.orders[0].Side, actualOrder.Side, "Side mismatch")
+				suite.Assert().Equal(tc.orders[0].Quantity, actualOrder.Quantity, "Quantity mismatch")
+				suite.Assert().Equal(tc.orders[0].Price, actualOrder.Price, "Price mismatch")
+				suite.Assert().Equal(tc.orders[0].Timestamp.UTC(), actualOrder.Timestamp.UTC(), "Timestamp mismatch")
+				suite.Assert().Equal(tc.orders[0].IsCompleted, actualOrder.IsCompleted, "IsCompleted mismatch")
+				suite.Assert().Equal(tc.orders[0].Reason.Reason, actualOrder.Reason.Reason, "Reason mismatch")
+				suite.Assert().Equal(tc.orders[0].Reason.Message, actualOrder.Reason.Message, "Message mismatch")
+				suite.Assert().Equal(tc.orders[0].StrategyName, actualOrder.StrategyName, "Strategy name mismatch")
+			} else {
+				suite.Assert().False(result.IsSome(), "Expected order to not exist")
+			}
+		})
+	}
+}
+
+func (suite *BacktestStateTestSuite) TestGetAllPositions() {
+	tests := []struct {
+		name        string
+		orders      []types.Order
+		expected    []types.Position
+		expectError bool
+	}{
+		{
+			name: "Single open position",
+			orders: []types.Order{
+				{
+					OrderID:     "order1",
+					Symbol:      "AAPL",
+					Side:        types.PurchaseTypeBuy,
+					Quantity:    100,
+					Price:       100.0,
+					Fee:         1.0,
+					Timestamp:   time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+					IsCompleted: true,
+					Reason: types.Reason{
+						Reason: "test",
+					},
+				},
+			},
+			expected: []types.Position{
+				{
+					Symbol:           "AAPL",
+					Quantity:         100,
+					TotalInQuantity:  100,
+					TotalOutQuantity: 0,
+					TotalInAmount:    10000.0,
+					TotalOutAmount:   0,
+					TotalInFee:       1.0,
+					TotalOutFee:      0,
+					OpenTimestamp:    time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+					StrategyName:     "",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "Multiple open positions",
+			orders: []types.Order{
+				{
+					OrderID:     "order1",
+					Symbol:      "AAPL",
+					Side:        types.PurchaseTypeBuy,
+					Quantity:    100,
+					Price:       100.0,
+					Fee:         1.0,
+					Timestamp:   time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+					IsCompleted: true,
+					Reason: types.Reason{
+						Reason: "test",
+					},
+				},
+				{
+					OrderID:     "order2",
+					Symbol:      "GOOGL",
+					Side:        types.PurchaseTypeBuy,
+					Quantity:    50,
+					Price:       2000.0,
+					Fee:         1.0,
+					Timestamp:   time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+					IsCompleted: true,
+					Reason: types.Reason{
+						Reason: "test",
+					},
+				},
+			},
+			expected: []types.Position{
+				{
+					Symbol:           "AAPL",
+					Quantity:         100,
+					TotalInQuantity:  100,
+					TotalOutQuantity: 0,
+					TotalInAmount:    10000.0,
+					TotalOutAmount:   0,
+					TotalInFee:       1.0,
+					TotalOutFee:      0,
+					OpenTimestamp:    time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+					StrategyName:     "",
+				},
+				{
+					Symbol:           "GOOGL",
+					Quantity:         50,
+					TotalInQuantity:  50,
+					TotalOutQuantity: 0,
+					TotalInAmount:    100000.0,
+					TotalOutAmount:   0,
+					TotalInFee:       1.0,
+					TotalOutFee:      0,
+					OpenTimestamp:    time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+					StrategyName:     "",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "Closed position",
+			orders: []types.Order{
+				{
+					OrderID:     "order1",
+					Symbol:      "AAPL",
+					Side:        types.PurchaseTypeBuy,
+					Quantity:    100,
+					Price:       100.0,
+					Fee:         1.0,
+					Timestamp:   time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+					IsCompleted: true,
+					Reason: types.Reason{
+						Reason: "test",
+					},
+				},
+				{
+					OrderID:     "order2",
+					Symbol:      "AAPL",
+					Side:        types.PurchaseTypeSell,
+					Quantity:    100,
+					Price:       110.0,
+					Fee:         1.0,
+					Timestamp:   time.Date(2024, 1, 1, 11, 0, 0, 0, time.UTC),
+					IsCompleted: true,
+					Reason: types.Reason{
+						Reason: "test",
+					},
+				},
+			},
+			expected:    []types.Position{},
+			expectError: false,
+		},
+		{
+			name:        "No positions",
+			orders:      []types.Order{},
+			expected:    []types.Position{},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			// Reset state before each test case
+			err := suite.state.Cleanup()
+			suite.Require().NoError(err)
+
+			// Process orders
+			for _, order := range tc.orders {
+				_, err := suite.state.Update([]types.Order{order})
+				suite.Require().NoError(err)
+			}
+
+			// Get all positions
+			positions, err := suite.state.GetAllPositions()
+			if tc.expectError {
+				suite.Assert().Error(err)
+				return
+			}
+
+			suite.Assert().NoError(err)
+			suite.Assert().Equal(len(tc.expected), len(positions), "Number of positions mismatch")
+
+			// Compare positions
+			for i, expected := range tc.expected {
+				if i >= len(positions) {
+					suite.T().Fatalf("Expected positions[%d] but got no more positions", i)
+				}
+				actual := positions[i]
+				suite.Assert().Equal(expected.Symbol, actual.Symbol, "Symbol mismatch")
+				suite.Assert().Equal(expected.Quantity, actual.Quantity, "Quantity mismatch")
+				suite.Assert().Equal(expected.TotalInQuantity, actual.TotalInQuantity, "Total in quantity mismatch")
+				suite.Assert().Equal(expected.TotalOutQuantity, actual.TotalOutQuantity, "Total out quantity mismatch")
+				suite.Assert().Equal(expected.TotalInAmount, actual.TotalInAmount, "Total in amount mismatch")
+				suite.Assert().Equal(expected.TotalOutAmount, actual.TotalOutAmount, "Total out amount mismatch")
+				suite.Assert().Equal(expected.TotalInFee, actual.TotalInFee, "Total in fee mismatch")
+				suite.Assert().Equal(expected.TotalOutFee, actual.TotalOutFee, "Total out fee mismatch")
+				suite.Assert().Equal(expected.OpenTimestamp.UTC(), actual.OpenTimestamp.UTC(), "Open timestamp mismatch")
+				suite.Assert().Equal(expected.StrategyName, actual.StrategyName, "Strategy name mismatch")
+			}
+		})
+	}
+}
+
+func (suite *BacktestStateTestSuite) TestGetPosition() {
+	tests := []struct {
+		name        string
+		orders      []types.Order
+		symbol      string
+		expected    types.Position
+		expectError bool
+	}{
+		{
+			name: "Single buy order",
+			orders: []types.Order{
+				{
+					OrderID:     "order1",
+					Symbol:      "AAPL",
+					Side:        types.PurchaseTypeBuy,
+					Quantity:    100,
+					Price:       100.0,
+					Fee:         1.0,
+					Timestamp:   time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+					IsCompleted: true,
+					Reason: types.Reason{
+						Reason: "test",
+					},
+				},
+			},
+			symbol: "AAPL",
+			expected: types.Position{
+				Symbol:           "AAPL",
+				Quantity:         100,
+				TotalInQuantity:  100,
+				TotalOutQuantity: 0,
+				TotalInAmount:    10000.0,
+				TotalOutAmount:   0,
+				TotalInFee:       1.0,
+				TotalOutFee:      0,
+				OpenTimestamp:    time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+				StrategyName:     "",
+			},
+			expectError: false,
+		},
+		{
+			name: "Multiple buys and sells",
+			orders: []types.Order{
+				{
+					OrderID:     "order1",
+					Symbol:      "AAPL",
+					Side:        types.PurchaseTypeBuy,
+					Quantity:    100,
+					Price:       100.0,
+					Fee:         1.0,
+					Timestamp:   time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+					IsCompleted: true,
+					Reason: types.Reason{
+						Reason: "test",
+					},
+				},
+				{
+					OrderID:     "order2",
+					Symbol:      "AAPL",
+					Side:        types.PurchaseTypeBuy,
+					Quantity:    50,
+					Price:       110.0,
+					Fee:         1.0,
+					Timestamp:   time.Date(2024, 1, 1, 11, 0, 0, 0, time.UTC),
+					IsCompleted: true,
+					Reason: types.Reason{
+						Reason: "test",
+					},
+				},
+				{
+					OrderID:     "order3",
+					Symbol:      "AAPL",
+					Side:        types.PurchaseTypeSell,
+					Quantity:    75,
+					Price:       120.0,
+					Fee:         1.0,
+					Timestamp:   time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+					IsCompleted: true,
+					Reason: types.Reason{
+						Reason: "test",
+					},
+				},
+			},
+			symbol: "AAPL",
+			expected: types.Position{
+				Symbol:           "AAPL",
+				Quantity:         75,  // 100 + 50 - 75
+				TotalInQuantity:  150, // 100 + 50
+				TotalOutQuantity: 75,
+				TotalInAmount:    15500.0, // (100 * 100) + (50 * 110)
+				TotalOutAmount:   9000.0,  // 75 * 120
+				TotalInFee:       2.0,     // 1 + 1
+				TotalOutFee:      1.0,
+				OpenTimestamp:    time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+				StrategyName:     "",
+			},
+			expectError: false,
+		},
+		{
+			name: "Fully closed position",
+			orders: []types.Order{
+				{
+					OrderID:     "order1",
+					Symbol:      "AAPL",
+					Side:        types.PurchaseTypeBuy,
+					Quantity:    100,
+					Price:       100.0,
+					Fee:         1.0,
+					Timestamp:   time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+					IsCompleted: true,
+					Reason: types.Reason{
+						Reason: "test",
+					},
+				},
+				{
+					OrderID:     "order2",
+					Symbol:      "AAPL",
+					Side:        types.PurchaseTypeSell,
+					Quantity:    100,
+					Price:       110.0,
+					Fee:         1.0,
+					Timestamp:   time.Date(2024, 1, 1, 11, 0, 0, 0, time.UTC),
+					IsCompleted: true,
+					Reason: types.Reason{
+						Reason: "test",
+					},
+				},
+			},
+			symbol: "AAPL",
+			expected: types.Position{
+				Symbol:           "AAPL",
+				Quantity:         0,
+				TotalInQuantity:  100,
+				TotalOutQuantity: 100,
+				TotalInAmount:    10000.0,
+				TotalOutAmount:   11000.0,
+				TotalInFee:       1.0,
+				TotalOutFee:      1.0,
+				OpenTimestamp:    time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+				StrategyName:     "",
+			},
+			expectError: false,
+		},
+		{
+			name: "Non-existent symbol",
+			orders: []types.Order{
+				{
+					OrderID:     "order1",
+					Symbol:      "AAPL",
+					Side:        types.PurchaseTypeBuy,
+					Quantity:    100,
+					Price:       100.0,
+					Fee:         1.0,
+					Timestamp:   time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+					IsCompleted: true,
+					Reason: types.Reason{
+						Reason: "test",
+					},
+				},
+			},
+			symbol: "GOOGL",
+			expected: types.Position{
+				Symbol:           "GOOGL",
+				Quantity:         0,
+				TotalInQuantity:  0,
+				TotalOutQuantity: 0,
+				TotalInAmount:    0,
+				TotalOutAmount:   0,
+				TotalInFee:       0,
+				TotalOutFee:      0,
+				OpenTimestamp:    time.Time{},
+				StrategyName:     "",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			// Reset state before each test case
+			err := suite.state.Cleanup()
+			suite.Require().NoError(err)
+
+			// Process orders
+			for _, order := range tc.orders {
+				_, err := suite.state.Update([]types.Order{order})
+				suite.Require().NoError(err)
+			}
+
+			// Get position
+			position, err := suite.state.GetPosition(tc.symbol)
+			if tc.expectError {
+				suite.Assert().Error(err)
+				return
+			}
+
+			suite.Assert().NoError(err)
+			suite.Assert().Equal(tc.expected.Symbol, position.Symbol, "Symbol mismatch")
+			suite.Assert().Equal(tc.expected.Quantity, position.Quantity, "Quantity mismatch")
+			suite.Assert().Equal(tc.expected.TotalInQuantity, position.TotalInQuantity, "Total in quantity mismatch")
+			suite.Assert().Equal(tc.expected.TotalOutQuantity, position.TotalOutQuantity, "Total out quantity mismatch")
+			suite.Assert().Equal(tc.expected.TotalInAmount, position.TotalInAmount, "Total in amount mismatch")
+			suite.Assert().Equal(tc.expected.TotalOutAmount, position.TotalOutAmount, "Total out amount mismatch")
+			suite.Assert().Equal(tc.expected.TotalInFee, position.TotalInFee, "Total in fee mismatch")
+			suite.Assert().Equal(tc.expected.TotalOutFee, position.TotalOutFee, "Total out fee mismatch")
+			suite.Assert().Equal(tc.expected.OpenTimestamp.UTC(), position.OpenTimestamp.UTC(), "Open timestamp mismatch")
+			suite.Assert().Equal(tc.expected.StrategyName, position.StrategyName, "Strategy name mismatch")
 		})
 	}
 }

--- a/src/strategy/strategy_test.go
+++ b/src/strategy/strategy_test.go
@@ -1,0 +1,267 @@
+package strategy_test
+
+import (
+	"testing"
+	"time"
+
+	engine "github.com/sirily11/argo-trading-go/src/backtest/engine/engine_v1"
+	"github.com/sirily11/argo-trading-go/src/backtest/engine/engine_v1/cache"
+	"github.com/sirily11/argo-trading-go/src/backtest/engine/engine_v1/commission_fee"
+	"github.com/sirily11/argo-trading-go/src/logger"
+	"github.com/sirily11/argo-trading-go/src/strategy"
+	"github.com/sirily11/argo-trading-go/src/trading"
+	"github.com/sirily11/argo-trading-go/src/types"
+	"github.com/stretchr/testify/suite"
+)
+
+// SimpleConsecutiveStrategy implements a strategy that buys on 2 consecutive up candles
+// and sells on 2 consecutive down candles
+type SimpleConsecutiveStrategy struct {
+	cache *cache.Cache
+}
+
+func (s *SimpleConsecutiveStrategy) Initialize(config string) error {
+	return nil
+}
+
+func (s *SimpleConsecutiveStrategy) ProcessData(ctx strategy.StrategyContext, data types.MarketData) error {
+	// Get previous data from cache
+	prevData, exists := (*s.cache).(*cache.CacheV1).Get("prev_data")
+	if !exists {
+		// First data point, just store it
+		(*s.cache).(*cache.CacheV1).Set("prev_data", data)
+		return nil
+	}
+
+	prevMarketData := prevData.(types.MarketData)
+
+	// Check for consecutive up candles
+	if data.Close > data.Open && prevMarketData.Close > prevMarketData.Open {
+		// Buy signal
+		order := types.ExecuteOrder{
+			Symbol:    data.Symbol,
+			Side:      types.PurchaseTypeBuy,
+			OrderType: types.OrderTypeLimit,
+			Quantity:  1.0, // Fixed quantity for testing
+			Price:     data.Close,
+			Reason: types.Reason{
+				Reason:  "strategy",
+				Message: "Two consecutive up candles",
+			},
+			StrategyName: s.Name(),
+		}
+		return (*ctx.TradingSystem).PlaceOrder(order)
+	}
+
+	// Check for consecutive down candles
+	if data.Close < data.Open && prevMarketData.Close < prevMarketData.Open {
+		// Sell signal
+		order := types.ExecuteOrder{
+			Symbol:    data.Symbol,
+			Side:      types.PurchaseTypeSell,
+			OrderType: types.OrderTypeLimit,
+			Quantity:  1.0, // Fixed quantity for testing
+			Price:     data.Close,
+			Reason: types.Reason{
+				Reason:  "strategy",
+				Message: "Two consecutive down candles",
+			},
+			StrategyName: s.Name(),
+		}
+		return (*ctx.TradingSystem).PlaceOrder(order)
+	}
+
+	// Update cache with current data
+	(*s.cache).(*cache.CacheV1).Set("prev_data", data)
+	return nil
+}
+
+func (s *SimpleConsecutiveStrategy) Name() string {
+	return "SimpleConsecutiveStrategy"
+}
+
+type StrategyTestSuite struct {
+	suite.Suite
+	strategy      *SimpleConsecutiveStrategy
+	cache         *cache.Cache
+	tradingSystem trading.TradingSystem
+	logger        *logger.Logger
+	state         *engine.BacktestState
+	commission    commission_fee.CommissionFee
+}
+
+// Test Suite
+func (suite *StrategyTestSuite) SetupSuite() {
+	logger, err := logger.NewLogger()
+	suite.Require().NoError(err)
+	suite.logger = logger
+	suite.state = engine.NewBacktestState(suite.logger)
+	suite.Require().NotNil(suite.state)
+	suite.commission = commission_fee.NewZeroCommissionFee()
+}
+
+func (suite *StrategyTestSuite) TearDownSuite() {
+	if suite.state != nil {
+		suite.state.Cleanup()
+	}
+}
+
+func (suite *StrategyTestSuite) SetupTest() {
+	// Initialize cache
+	cacheV1 := cache.NewCacheV1()
+	suite.cache = &cacheV1
+
+	// Initialize state
+	err := suite.state.Initialize()
+	suite.Require().NoError(err)
+
+	// Create real trading system
+	suite.tradingSystem = engine.NewBacktestTrading(*suite.state, 10000.0, suite.commission)
+
+	// Initialize strategy
+	suite.strategy = &SimpleConsecutiveStrategy{
+		cache: suite.cache,
+	}
+}
+
+func (suite *StrategyTestSuite) TearDownTest() {
+	err := suite.state.Cleanup()
+	suite.Require().NoError(err)
+}
+
+func (suite *StrategyTestSuite) TestConsecutiveUpCandles() {
+	// Create test context
+	tradingSystem := suite.tradingSystem
+	ctx := strategy.StrategyContext{
+		Cache:         suite.cache,
+		TradingSystem: &tradingSystem,
+	}
+
+	// First up candle
+	data1 := types.MarketData{
+		Symbol: "BTCUSDT",
+		Open:   100.0,
+		High:   110.0,
+		Low:    95.0,
+		Close:  105.0,
+		Volume: 1000.0,
+		Time:   time.Now(),
+	}
+
+	// Second up candle
+	data2 := types.MarketData{
+		Symbol: "BTCUSDT",
+		Open:   105.0,
+		High:   115.0,
+		Low:    100.0,
+		Close:  110.0,
+		Volume: 1000.0,
+		Time:   time.Now().Add(time.Minute),
+	}
+
+	// Update market data in trading system
+	suite.tradingSystem.(*engine.BacktestTrading).UpdateCurrentMarketData(data1)
+
+	// Process first candle (should just store in cache)
+	err := suite.strategy.ProcessData(ctx, data1)
+	suite.NoError(err)
+
+	// Update market data in trading system
+	suite.tradingSystem.(*engine.BacktestTrading).UpdateCurrentMarketData(data2)
+
+	// Process second candle (should trigger buy)
+	err = suite.strategy.ProcessData(ctx, data2)
+	suite.NoError(err)
+
+	// Verify that a buy order was placed
+	position, err := suite.tradingSystem.GetPosition("BTCUSDT")
+	suite.NoError(err)
+	suite.Equal(1.0, position.Quantity)
+}
+
+func (suite *StrategyTestSuite) TestConsecutiveDownCandles() {
+	// Create test context
+	tradingSystem := suite.tradingSystem
+	ctx := strategy.StrategyContext{
+		Cache:         suite.cache,
+		TradingSystem: &tradingSystem,
+	}
+
+	// First establish a position by buying
+	buyOrder := types.ExecuteOrder{
+		Symbol:    "BTCUSDT",
+		Side:      types.PurchaseTypeBuy,
+		OrderType: types.OrderTypeLimit,
+		Quantity:  1,
+		Price:     10000.0, // Adjusted price to match the test data
+		Reason: types.Reason{
+			Reason:  "test",
+			Message: "Establish initial position",
+		},
+		StrategyName: "Test",
+	}
+	var err error
+	tradingSystem.(*engine.BacktestTrading).UpdateCurrentMarketData(types.MarketData{
+		Symbol: "BTCUSDT",
+		Open:   10000.0,
+		High:   11000.0,
+		Low:    9500.0,
+		Close:  10000.0,
+		Volume: 1000.0,
+		Time:   time.Now(),
+	})
+	tradingSystem.(*engine.BacktestTrading).UpdateBalance(100000.0)
+	err = tradingSystem.PlaceOrder(buyOrder)
+	suite.NoError(err)
+
+	// Verify initial position
+	var position types.Position
+	position, err = suite.tradingSystem.GetPosition("BTCUSDT")
+	suite.NoError(err)
+	suite.Equal(1.0, position.Quantity)
+
+	// First down candle
+	data1 := types.MarketData{
+		Symbol: "BTCUSDT",
+		Open:   11000.0,
+		High:   11500.0,
+		Low:    10000.0,
+		Close:  10500.0,
+		Volume: 1000.0,
+		Time:   time.Now(),
+	}
+
+	// Second down candle
+	data2 := types.MarketData{
+		Symbol: "BTCUSDT",
+		Open:   10500.0,
+		High:   11000.0,
+		Low:    9500.0,
+		Close:  10000.0,
+		Volume: 1000.0,
+		Time:   time.Now().Add(time.Minute),
+	}
+
+	// Update market data in trading system
+	suite.tradingSystem.(*engine.BacktestTrading).UpdateCurrentMarketData(data1)
+
+	// Process first candle (should just store in cache)
+	err = suite.strategy.ProcessData(ctx, data1)
+	suite.NoError(err)
+
+	// Update market data in trading system
+	suite.tradingSystem.(*engine.BacktestTrading).UpdateCurrentMarketData(data2)
+
+	// Process second candle (should trigger sell)
+	err = suite.strategy.ProcessData(ctx, data2)
+	suite.NoError(err)
+
+	// Verify that the position was sold
+	position, err = suite.tradingSystem.GetPosition("BTCUSDT")
+	suite.NoError(err)
+	suite.Equal(0.0, position.Quantity)
+}
+
+func TestStrategySuite(t *testing.T) {
+	suite.Run(t, new(StrategyTestSuite))
+}

--- a/src/types/order.go
+++ b/src/types/order.go
@@ -17,6 +17,7 @@ const (
 	OrderStatusFilled    OrderStatus = "FILLED"
 	OrderStatusCancelled OrderStatus = "CANCELLED"
 	OrderStatusRejected  OrderStatus = "REJECTED"
+	OrderStatusFailed    OrderStatus = "Failed"
 )
 
 const (
@@ -47,12 +48,14 @@ type ExecuteOrderTakeProfitOrStopLoss struct {
 }
 
 type ExecuteOrder struct {
-	Symbol    string       `yaml:"symbol" json:"symbol" csv:"symbol"`
-	Side      PurchaseType `yaml:"side" json:"side" csv:"side"`
-	OrderType OrderType    `yaml:"order_type" json:"order_type" csv:"order_type"`
-	Reason    Reason       `yaml:"reason" json:"reason" csv:"reason"`
-	Price     float64      `yaml:"price" json:"price" csv:"price"`
-	Quantity  float64      `yaml:"quantity" json:"quantity" csv:"quantity"`
+	ID           string       `yaml:"id" json:"id" csv:"id" validate:"required,uuid"`
+	Symbol       string       `yaml:"symbol" json:"symbol" csv:"symbol" validate:"required"`
+	Side         PurchaseType `yaml:"side" json:"side" csv:"side" validate:"required,oneof=BUY SELL"`
+	OrderType    OrderType    `yaml:"order_type" json:"order_type" csv:"order_type" validate:"required,oneof=MARKET LIMIT"`
+	Reason       Reason       `yaml:"reason" json:"reason" csv:"reason" validate:"required"`
+	Price        float64      `yaml:"price" json:"price" csv:"price" validate:"required,gt=0"`
+	StrategyName string       `yaml:"strategy_name" json:"strategy_name" csv:"strategy_name" validate:"required"`
+	Quantity     float64      `yaml:"quantity" json:"quantity" csv:"quantity" validate:"required,gt=0"`
 	// TakeProfit is the take profit order. Can be nil if not set.
 	TakeProfit optional.Option[ExecuteOrderTakeProfitOrStopLoss] `yaml:"take_profit" json:"take_profit" csv:"take_profit"`
 	// StopLoss is the stop loss order. Can be nil if not set.
@@ -60,13 +63,14 @@ type ExecuteOrder struct {
 }
 
 type Order struct {
-	OrderID     string       `yaml:"order_id" json:"order_id" csv:"order_id"`
-	Symbol      string       `yaml:"symbol" json:"symbol" csv:"symbol"`
-	Side        PurchaseType `yaml:"side" json:"side" csv:"side"`
-	Quantity    float64      `yaml:"quantity" json:"quantity" csv:"quantity"`
-	Price       float64      `yaml:"price" json:"price" csv:"price"`
-	Timestamp   time.Time    `yaml:"timestamp" json:"timestamp" csv:"timestamp"`
-	IsCompleted bool         `yaml:"is_completed" json:"is_completed" csv:"is_completed"`
+	OrderID   string       `yaml:"order_id" json:"order_id" csv:"order_id"`
+	Symbol    string       `yaml:"symbol" json:"symbol" csv:"symbol"`
+	Side      PurchaseType `yaml:"side" json:"side" csv:"side"`
+	Quantity  float64      `yaml:"quantity" json:"quantity" csv:"quantity"`
+	Price     float64      `yaml:"price" json:"price" csv:"price"`
+	Timestamp time.Time    `yaml:"timestamp" json:"timestamp" csv:"timestamp"`
+	// IsCompleted is true if the order has been filled or cancelled
+	IsCompleted bool `yaml:"is_completed" json:"is_completed" csv:"is_completed"`
 	// Reason is the reason for the order
 	// It can be used to store the reason for the order
 	// like "buy_signal", "sell_signal", "stop_loss", "take_profit", etc.


### PR DESCRIPTION
This pull request introduces significant updates to the `argo-trading-go` repository, including new dependencies, enhancements to the backtesting engine, and improvements to the caching system. The most important changes are summarized below:

### Dependency Updates:
* Added new dependencies: `github.com/Masterminds/squirrel`, `github.com/go-playground/validator`, and `github.com/google/uuid` in `go.mod`.
* Removed outdated dependencies: `github.com/alifiroozi80/duckdb`, `gorm.io/gorm`, `github.com/google/uuid`, `github.com/jinzhu/inflection`, and `github.com/jinzhu/now` in `go.mod`. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L18-L22) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L38-L40)

### Backtesting Engine Enhancements:
* Introduced `BacktestTrading` struct and implemented various methods such as `UpdateCurrentMarketData`, `CancelAllOrders`, `CancelOrder`, `GetOrderStatus`, `GetPosition`, `GetPositions`, `PlaceMultipleOrders`, `PlaceOrder`, and `getBuyingPower` in `src/backtest/engine/engine_v1/backtest_trading.go`.
* Updated the `BacktestState` to use string-based `order_id` instead of sequence-based in `src/backtest/engine/engine_v1/state.go`. [[1]](diffhunk://#diff-44a25e84c61c4d08b0ce67719e1ab9df3ae85a33b554d81f4fc30a56503736f5L50-R54) [[2]](diffhunk://#diff-44a25e84c61c4d08b0ce67719e1ab9df3ae85a33b554d81f4fc30a56503736f5L72-R73) [[3]](diffhunk://#diff-44a25e84c61c4d08b0ce67719e1ab9df3ae85a33b554d81f4fc30a56503736f5L114-R129) [[4]](diffhunk://#diff-44a25e84c61c4d08b0ce67719e1ab9df3ae85a33b554d81f4fc30a56503736f5L157-R156) [[5]](diffhunk://#diff-44a25e84c61c4d08b0ce67719e1ab9df3ae85a33b554d81f4fc30a56503736f5L184-R183)
* Added `GetOrderById` and `GetAllPositions` methods to `BacktestState` in `src/backtest/engine/engine_v1/state.go`.

### Caching System Improvements:
* Enhanced `CacheV1` struct by adding `otherData` map and implemented `Set` and `Get` methods in `src/backtest/engine/engine_v1/cache/cache.go`.
* Added unit tests for `CacheV1` including tests for `NewCacheV1`, `Reset`, `SetAndGet`, and `RangeFilterState` in `src/backtest/engine/engine_v1/cache/cache_test.go`.

### Order and Trade Enhancements:
* Added a new order status `OrderStatusFailed` in `src/types/order.go`.
* Updated `ExecuteOrder` struct to include validation tags and a new `ID` field in `src/types/order.go`.
* Added documentation for the `IsCompleted` field in the `Order` struct in `src/types/order.go`.