### PR TITLE
refactor: replace string color representation with MarkColor type

### DIFF
--- a/.github/workflows/build-github-page.yaml
+++ b/.github/workflows/build-github-page.yaml
@@ -28,7 +28,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
+            - name: Setup Python
+              uses: actions/setup-python@v6
+              with:
+                  python-version: "3.x"
+            - name: Generate docs index
+              run: python scripts/generate_docs_index.py
             - name: Setup Pages
               uses: actions/configure-pages@v5
             - name: Build with Jekyll

--- a/e2e/backtest/wasm/testhelper/testhelper.go
+++ b/e2e/backtest/wasm/testhelper/testhelper.go
@@ -439,7 +439,7 @@ func ReadMarker(s *E2ETestSuite, tmpFolder string) (marker []types.Mark, err err
 		// Create mark with the new fields
 		mark := types.Mark{
 			MarketDataId: marketDataId,
-			Color:        color,
+			Color:        types.MarkColor(color),
 			Shape:        types.MarkShape(shapeStr),
 			Title:        title,
 			Message:      message,

--- a/internal/backtest/engine/engine_v1/backtest_marker.go
+++ b/internal/backtest/engine/engine_v1/backtest_marker.go
@@ -145,7 +145,7 @@ func (m *BacktestMarker) GetMarks() ([]types.Mark, error) {
 
 		var signalSymbol sql.NullString
 
-		var color string
+		var color types.MarkColor
 
 		var shapeStr string
 

--- a/internal/runtime/wasm/strategy_api.go
+++ b/internal/runtime/wasm/strategy_api.go
@@ -179,7 +179,7 @@ func (s StrategyApiForWasm) GetMarkers(ctx context.Context, _ *emptypb.Empty) (*
 		}
 
 		response.Markers[i] = &strategy.Mark{
-			Color:      mark.Color,
+			Color:      string(mark.Color),
 			Shape:      runtime.MarkShapeToStrategyMarkShape(mark.Shape),
 			Title:      mark.Title,
 			Message:    mark.Message,
@@ -385,7 +385,7 @@ func (s StrategyApiForWasm) Mark(ctx context.Context, req *strategy.MarkRequest)
 
 	mark := types.Mark{
 		MarketDataId: "",
-		Color:        req.Mark.Color,
+		Color:        types.MarkColor(req.Mark.Color),
 		Shape:        runtime.StrategyMarkShapeToMarkShape(req.Mark.Shape),
 		Title:        req.Mark.Title,
 		Message:      req.Mark.Message,

--- a/internal/runtime/wasm/strategy_api_test.go
+++ b/internal/runtime/wasm/strategy_api_test.go
@@ -581,7 +581,7 @@ func (suite *StrategyApiTestSuite) TestMark() {
 			suite.Equal(expectedMarketData.Volume, md.Volume)
 
 			// Verify the mark
-			suite.Equal("red", mark.Color)
+			suite.Equal(types.MarkColor("red"), mark.Color)
 			suite.Equal(types.MarkShapeCircle, mark.Shape)
 			suite.Equal("Test mark title", mark.Title)
 			suite.Equal("Test mark message", mark.Message)

--- a/internal/types/mark.go
+++ b/internal/types/mark.go
@@ -10,9 +10,20 @@ const (
 	MarkShapeTriangle MarkShape = "triangle"
 )
 
+type MarkColor string
+
+const (
+	MarkColorRed    MarkColor = "red"
+	MarkColorGreen  MarkColor = "green"
+	MarkColorBlue   MarkColor = "blue"
+	MarkColorYellow MarkColor = "yellow"
+	MarkColorPurple MarkColor = "purple"
+	MarkColorOrange MarkColor = "orange"
+)
+
 type Mark struct {
 	MarketDataId string
-	Color        string
+	Color        MarkColor
 	Shape        MarkShape
 	Title        string
 	Message      string

--- a/internal/types/mark_test.go
+++ b/internal/types/mark_test.go
@@ -49,7 +49,7 @@ func (suite *MarkTestSuite) TestMarkStruct() {
 	}
 
 	suite.Equal("md-123", mark.MarketDataId)
-	suite.Equal("#FF0000", mark.Color)
+	suite.Equal(MarkColor("#FF0000"), mark.Color)
 	suite.Equal(MarkShapeCircle, mark.Shape)
 	suite.Equal("Buy Signal", mark.Title)
 	suite.Equal("RSI indicates oversold condition", mark.Message)
@@ -102,14 +102,13 @@ func (suite *MarkTestSuite) TestMarkShapes() {
 }
 
 func (suite *MarkTestSuite) TestMarkColors() {
-	colors := []string{
-		"#FF0000", // red
-		"#00FF00", // green
-		"#0000FF", // blue
-		"#FFFF00", // yellow
-		"rgb(255, 0, 0)",
-		"rgba(255, 0, 0, 0.5)",
-		"red",
+	colors := []MarkColor{
+		MarkColorRed,
+		MarkColorGreen,
+		MarkColorBlue,
+		MarkColorYellow,
+		MarkColorPurple,
+		MarkColorOrange,
 	}
 
 	for _, color := range colors {

--- a/pkg/strategy/strategy.pb.go
+++ b/pkg/strategy/strategy.pb.go
@@ -1506,6 +1506,9 @@ type Mark struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
+	// color of the mark.
+	// Supported color strings are: red, green, blue, yellow, purple, orange
+	// or hex color like #FF0000
 	Color      string     `protobuf:"bytes,1,opt,name=color,proto3" json:"color,omitempty"`
 	Shape      MarkShape  `protobuf:"varint,2,opt,name=shape,proto3,enum=strategy.MarkShape" json:"shape,omitempty"`
 	Title      string     `protobuf:"bytes,3,opt,name=title,proto3" json:"title,omitempty"`

--- a/pkg/strategy/strategy.proto
+++ b/pkg/strategy/strategy.proto
@@ -384,7 +384,11 @@ enum MarkShape {
   MARK_SHAPE_TRIANGLE = 2;
 }
 
+
 message Mark {
+  // color of the mark.
+  // Supported color strings are: red, green, blue, yellow, purple, orange
+  // or hex color like #FF0000
   string color = 1;
   MarkShape shape = 2;
   string title = 3;


### PR DESCRIPTION
- Updated the Mark struct to use MarkColor instead of string for color representation.
- Adjusted related functions and tests to accommodate the new MarkColor type.
- Enhanced type safety and clarity in color handling across the backtest and strategy API.