### PR TITLE
feat: add market data client configurations and validation

### DIFF
--- a/pkg/marketdata/client.go
+++ b/pkg/marketdata/client.go
@@ -87,6 +87,40 @@ func NewClient(config ClientConfig, onProgress provider.OnDownloadProgress) (*Cl
 	}, nil
 }
 
+// NewClientFromPolygonConfig creates a new client from a PolygonDownloadConfig.
+func NewClientFromPolygonConfig(config *PolygonDownloadConfig, onProgress provider.OnDownloadProgress) (*Client, DownloadParams, error) {
+	clientConfig := config.ToClientConfig()
+
+	client, err := NewClient(clientConfig, onProgress)
+	if err != nil {
+		return nil, DownloadParams{}, err
+	}
+
+	params, err := config.ToDownloadParams()
+	if err != nil {
+		return nil, DownloadParams{}, err
+	}
+
+	return client, params, nil
+}
+
+// NewClientFromBinanceConfig creates a new client from a BinanceDownloadConfig.
+func NewClientFromBinanceConfig(config *BinanceDownloadConfig, onProgress provider.OnDownloadProgress) (*Client, DownloadParams, error) {
+	clientConfig := config.ToClientConfig()
+
+	client, err := NewClient(clientConfig, onProgress)
+	if err != nil {
+		return nil, DownloadParams{}, err
+	}
+
+	params, err := config.ToDownloadParams()
+	if err != nil {
+		return nil, DownloadParams{}, err
+	}
+
+	return client, params, nil
+}
+
 // Download initiates a market data download with the given parameters.
 // The context can be used to cancel the download operation.
 func (c *Client) Download(ctx context.Context, params DownloadParams) error {

--- a/pkg/marketdata/download_config.go
+++ b/pkg/marketdata/download_config.go
@@ -1,0 +1,136 @@
+package marketdata
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// BaseDownloadConfig contains common fields for all download configurations.
+type BaseDownloadConfig struct {
+	Ticker    string `json:"ticker" jsonschema:"title=Ticker,description=The trading symbol to download data for (e.g. SPY or BTCUSDT),required" validate:"required"`
+	StartDate string `json:"startDate" jsonschema:"title=Start Date,description=Start date in RFC3339 format (e.g. 2024-01-01T00:00:00Z),required" validate:"required"`
+	EndDate   string `json:"endDate" jsonschema:"title=End Date,description=End date in RFC3339 format (e.g. 2024-12-31T23:59:59Z),required" validate:"required"`
+	Interval  string `json:"interval" jsonschema:"title=Interval,description=Data interval,required,enum=1s,enum=1m,enum=3m,enum=5m,enum=15m,enum=30m,enum=1h,enum=2h,enum=4h,enum=6h,enum=8h,enum=12h,enum=1d,enum=3d,enum=1w,enum=1M" validate:"required,oneof=1s 1m 3m 5m 15m 30m 1h 2h 4h 6h 8h 12h 1d 3d 1w 1M"`
+	DataPath  string `json:"dataPath" jsonschema:"title=Data Path,description=Directory path where downloaded data will be saved,required" validate:"required"`
+}
+
+// PolygonDownloadConfig contains configuration for downloading from Polygon.io.
+type PolygonDownloadConfig struct {
+	BaseDownloadConfig
+
+	ApiKey string `json:"apiKey" jsonschema:"title=API Key,description=Polygon.io API key for authentication,required" validate:"required"`
+}
+
+// BinanceDownloadConfig contains configuration for downloading from Binance.
+// Binance public market data API does not require authentication.
+type BinanceDownloadConfig struct {
+	BaseDownloadConfig
+}
+
+// Validate validates the BaseDownloadConfig fields.
+func (c *BaseDownloadConfig) Validate() error {
+	validate := validator.New()
+	if err := validate.Struct(c); err != nil {
+		return fmt.Errorf("invalid config: %w", err)
+	}
+
+	// Validate date formats
+	if _, err := time.Parse(time.RFC3339, c.StartDate); err != nil {
+		return fmt.Errorf("invalid startDate format, expected RFC3339: %w", err)
+	}
+
+	if _, err := time.Parse(time.RFC3339, c.EndDate); err != nil {
+		return fmt.Errorf("invalid endDate format, expected RFC3339: %w", err)
+	}
+
+	return nil
+}
+
+// Validate validates the PolygonDownloadConfig.
+func (c *PolygonDownloadConfig) Validate() error {
+	validate := validator.New()
+	if err := validate.Struct(c); err != nil {
+		return fmt.Errorf("invalid config: %w", err)
+	}
+
+	return c.BaseDownloadConfig.Validate()
+}
+
+// Validate validates the BinanceDownloadConfig.
+func (c *BinanceDownloadConfig) Validate() error {
+	return c.BaseDownloadConfig.Validate()
+}
+
+// ToDownloadParams converts a BaseDownloadConfig to DownloadParams.
+func (c *BaseDownloadConfig) ToDownloadParams() (DownloadParams, error) {
+	startDate, err := time.Parse(time.RFC3339, c.StartDate)
+	if err != nil {
+		return DownloadParams{}, fmt.Errorf("failed to parse startDate: %w", err)
+	}
+
+	endDate, err := time.Parse(time.RFC3339, c.EndDate)
+	if err != nil {
+		return DownloadParams{}, fmt.Errorf("failed to parse endDate: %w", err)
+	}
+
+	timespan := Timespan(c.Interval)
+
+	return DownloadParams{
+		Ticker:     c.Ticker,
+		StartDate:  startDate,
+		EndDate:    endDate,
+		Multiplier: timespan.Multiplier(),
+		Timespan:   timespan.Timespan(),
+	}, nil
+}
+
+// ToClientConfig converts a PolygonDownloadConfig to ClientConfig.
+func (c *PolygonDownloadConfig) ToClientConfig() ClientConfig {
+	return ClientConfig{
+		ProviderType:  ProviderPolygon,
+		WriterType:    WriterDuckDB,
+		DataPath:      c.DataPath,
+		PolygonApiKey: c.ApiKey,
+	}
+}
+
+// ToClientConfig converts a BinanceDownloadConfig to ClientConfig.
+func (c *BinanceDownloadConfig) ToClientConfig() ClientConfig {
+	return ClientConfig{
+		ProviderType:  ProviderBinance,
+		WriterType:    WriterDuckDB,
+		DataPath:      c.DataPath,
+		PolygonApiKey: "",
+	}
+}
+
+// ParsePolygonConfig parses JSON into a PolygonDownloadConfig.
+func ParsePolygonConfig(jsonConfig string) (*PolygonDownloadConfig, error) {
+	var config PolygonDownloadConfig
+	if err := json.Unmarshal([]byte(jsonConfig), &config); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON config: %w", err)
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+// ParseBinanceConfig parses JSON into a BinanceDownloadConfig.
+func ParseBinanceConfig(jsonConfig string) (*BinanceDownloadConfig, error) {
+	var config BinanceDownloadConfig
+	if err := json.Unmarshal([]byte(jsonConfig), &config); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON config: %w", err)
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}

--- a/pkg/marketdata/download_config_test.go
+++ b/pkg/marketdata/download_config_test.go
@@ -1,0 +1,297 @@
+package marketdata
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type DownloadConfigTestSuite struct {
+	suite.Suite
+}
+
+func TestDownloadConfigTestSuite(t *testing.T) {
+	suite.Run(t, new(DownloadConfigTestSuite))
+}
+
+func (suite *DownloadConfigTestSuite) TestPolygonConfigValidation_Valid() {
+	config := &PolygonDownloadConfig{
+		BaseDownloadConfig: BaseDownloadConfig{
+			Ticker:    "SPY",
+			StartDate: "2024-01-01T00:00:00Z",
+			EndDate:   "2024-12-31T23:59:59Z",
+			Interval:  "1d",
+			DataPath:  "/tmp/data",
+		},
+		ApiKey: "test-api-key",
+	}
+
+	err := config.Validate()
+	suite.NoError(err)
+}
+
+func (suite *DownloadConfigTestSuite) TestPolygonConfigValidation_MissingTicker() {
+	config := &PolygonDownloadConfig{
+		BaseDownloadConfig: BaseDownloadConfig{
+			Ticker:    "",
+			StartDate: "2024-01-01T00:00:00Z",
+			EndDate:   "2024-12-31T23:59:59Z",
+			Interval:  "1d",
+			DataPath:  "/tmp/data",
+		},
+		ApiKey: "test-api-key",
+	}
+
+	err := config.Validate()
+	suite.Error(err)
+	suite.Contains(err.Error(), "Ticker")
+}
+
+func (suite *DownloadConfigTestSuite) TestPolygonConfigValidation_MissingApiKey() {
+	config := &PolygonDownloadConfig{
+		BaseDownloadConfig: BaseDownloadConfig{
+			Ticker:    "SPY",
+			StartDate: "2024-01-01T00:00:00Z",
+			EndDate:   "2024-12-31T23:59:59Z",
+			Interval:  "1d",
+			DataPath:  "/tmp/data",
+		},
+		ApiKey: "",
+	}
+
+	err := config.Validate()
+	suite.Error(err)
+	suite.Contains(err.Error(), "ApiKey")
+}
+
+func (suite *DownloadConfigTestSuite) TestPolygonConfigValidation_InvalidInterval() {
+	config := &PolygonDownloadConfig{
+		BaseDownloadConfig: BaseDownloadConfig{
+			Ticker:    "SPY",
+			StartDate: "2024-01-01T00:00:00Z",
+			EndDate:   "2024-12-31T23:59:59Z",
+			Interval:  "invalid",
+			DataPath:  "/tmp/data",
+		},
+		ApiKey: "test-api-key",
+	}
+
+	err := config.Validate()
+	suite.Error(err)
+	suite.Contains(err.Error(), "Interval")
+}
+
+func (suite *DownloadConfigTestSuite) TestPolygonConfigValidation_InvalidDateFormat() {
+	config := &PolygonDownloadConfig{
+		BaseDownloadConfig: BaseDownloadConfig{
+			Ticker:    "SPY",
+			StartDate: "2024-01-01", // Missing time component
+			EndDate:   "2024-12-31T23:59:59Z",
+			Interval:  "1d",
+			DataPath:  "/tmp/data",
+		},
+		ApiKey: "test-api-key",
+	}
+
+	err := config.Validate()
+	suite.Error(err)
+	suite.Contains(err.Error(), "startDate")
+}
+
+func (suite *DownloadConfigTestSuite) TestBinanceConfigValidation_Valid() {
+	config := &BinanceDownloadConfig{
+		BaseDownloadConfig: BaseDownloadConfig{
+			Ticker:    "BTCUSDT",
+			StartDate: "2024-01-01T00:00:00Z",
+			EndDate:   "2024-12-31T23:59:59Z",
+			Interval:  "1h",
+			DataPath:  "/tmp/data",
+		},
+	}
+
+	err := config.Validate()
+	suite.NoError(err)
+}
+
+func (suite *DownloadConfigTestSuite) TestBinanceConfigValidation_MissingFields() {
+	config := &BinanceDownloadConfig{
+		BaseDownloadConfig: BaseDownloadConfig{
+			Ticker:    "",
+			StartDate: "2024-01-01T00:00:00Z",
+			EndDate:   "2024-12-31T23:59:59Z",
+			Interval:  "1h",
+			DataPath:  "/tmp/data",
+		},
+	}
+
+	err := config.Validate()
+	suite.Error(err)
+}
+
+func (suite *DownloadConfigTestSuite) TestParsePolygonConfig_Valid() {
+	jsonConfig := `{
+		"ticker": "SPY",
+		"startDate": "2024-01-01T00:00:00Z",
+		"endDate": "2024-12-31T23:59:59Z",
+		"interval": "1d",
+		"dataPath": "/tmp/data",
+		"apiKey": "test-api-key"
+	}`
+
+	config, err := ParsePolygonConfig(jsonConfig)
+	suite.NoError(err)
+	suite.Equal("SPY", config.Ticker)
+	suite.Equal("test-api-key", config.ApiKey)
+}
+
+func (suite *DownloadConfigTestSuite) TestParsePolygonConfig_InvalidJSON() {
+	jsonConfig := `{invalid json}`
+
+	_, err := ParsePolygonConfig(jsonConfig)
+	suite.Error(err)
+	suite.Contains(err.Error(), "failed to parse JSON")
+}
+
+func (suite *DownloadConfigTestSuite) TestParsePolygonConfig_MissingRequiredField() {
+	jsonConfig := `{
+		"ticker": "SPY",
+		"startDate": "2024-01-01T00:00:00Z",
+		"endDate": "2024-12-31T23:59:59Z",
+		"interval": "1d",
+		"dataPath": "/tmp/data"
+	}`
+
+	_, err := ParsePolygonConfig(jsonConfig)
+	suite.Error(err)
+	suite.Contains(err.Error(), "ApiKey")
+}
+
+func (suite *DownloadConfigTestSuite) TestParseBinanceConfig_Valid() {
+	jsonConfig := `{
+		"ticker": "BTCUSDT",
+		"startDate": "2024-01-01T00:00:00Z",
+		"endDate": "2024-12-31T23:59:59Z",
+		"interval": "1h",
+		"dataPath": "/tmp/data"
+	}`
+
+	config, err := ParseBinanceConfig(jsonConfig)
+	suite.NoError(err)
+	suite.Equal("BTCUSDT", config.Ticker)
+	suite.Equal("1h", config.Interval)
+}
+
+func (suite *DownloadConfigTestSuite) TestToDownloadParams() {
+	config := &BaseDownloadConfig{
+		Ticker:    "SPY",
+		StartDate: "2024-01-01T00:00:00Z",
+		EndDate:   "2024-12-31T23:59:59Z",
+		Interval:  "1d",
+		DataPath:  "/tmp/data",
+	}
+
+	params, err := config.ToDownloadParams()
+	suite.NoError(err)
+	suite.Equal("SPY", params.Ticker)
+	suite.Equal(1, params.Multiplier)
+}
+
+func (suite *DownloadConfigTestSuite) TestPolygonToClientConfig() {
+	config := &PolygonDownloadConfig{
+		BaseDownloadConfig: BaseDownloadConfig{
+			Ticker:    "SPY",
+			StartDate: "2024-01-01T00:00:00Z",
+			EndDate:   "2024-12-31T23:59:59Z",
+			Interval:  "1d",
+			DataPath:  "/tmp/data",
+		},
+		ApiKey: "test-api-key",
+	}
+
+	clientConfig := config.ToClientConfig()
+	suite.Equal(ProviderPolygon, clientConfig.ProviderType)
+	suite.Equal(WriterDuckDB, clientConfig.WriterType)
+	suite.Equal("/tmp/data", clientConfig.DataPath)
+	suite.Equal("test-api-key", clientConfig.PolygonApiKey)
+}
+
+func (suite *DownloadConfigTestSuite) TestBinanceToClientConfig() {
+	config := &BinanceDownloadConfig{
+		BaseDownloadConfig: BaseDownloadConfig{
+			Ticker:    "BTCUSDT",
+			StartDate: "2024-01-01T00:00:00Z",
+			EndDate:   "2024-12-31T23:59:59Z",
+			Interval:  "1h",
+			DataPath:  "/tmp/data",
+		},
+	}
+
+	clientConfig := config.ToClientConfig()
+	suite.Equal(ProviderBinance, clientConfig.ProviderType)
+	suite.Equal(WriterDuckDB, clientConfig.WriterType)
+	suite.Equal("/tmp/data", clientConfig.DataPath)
+}
+
+func (suite *DownloadConfigTestSuite) TestAllIntervals() {
+	intervals := []string{"1s", "1m", "3m", "5m", "15m", "30m", "1h", "2h", "4h", "6h", "8h", "12h", "1d", "3d", "1w", "1M"}
+
+	for _, interval := range intervals {
+		config := &BinanceDownloadConfig{
+			BaseDownloadConfig: BaseDownloadConfig{
+				Ticker:    "BTCUSDT",
+				StartDate: "2024-01-01T00:00:00Z",
+				EndDate:   "2024-12-31T23:59:59Z",
+				Interval:  interval,
+				DataPath:  "/tmp/data",
+			},
+		}
+
+		err := config.Validate()
+		suite.NoError(err, "interval %s should be valid", interval)
+	}
+}
+
+func (suite *DownloadConfigTestSuite) TestPolygonConfigJSONSchema() {
+	schema, err := GetDownloadConfigSchema("polygon")
+	suite.NoError(err)
+	suite.NotEmpty(schema)
+
+	// Verify it's valid JSON
+	var schemaMap map[string]interface{}
+	err = json.Unmarshal([]byte(schema), &schemaMap)
+	suite.NoError(err)
+
+	// Check that required fields are in the schema
+	properties, ok := schemaMap["properties"].(map[string]interface{})
+	suite.True(ok, "schema should have properties")
+	suite.Contains(properties, "ticker")
+	suite.Contains(properties, "startDate")
+	suite.Contains(properties, "endDate")
+	suite.Contains(properties, "interval")
+	suite.Contains(properties, "dataPath")
+	suite.Contains(properties, "apiKey")
+}
+
+func (suite *DownloadConfigTestSuite) TestBinanceConfigJSONSchema() {
+	schema, err := GetDownloadConfigSchema("binance")
+	suite.NoError(err)
+	suite.NotEmpty(schema)
+
+	// Verify it's valid JSON
+	var schemaMap map[string]interface{}
+	err = json.Unmarshal([]byte(schema), &schemaMap)
+	suite.NoError(err)
+
+	// Check that required fields are in the schema
+	properties, ok := schemaMap["properties"].(map[string]interface{})
+	suite.True(ok, "schema should have properties")
+	suite.Contains(properties, "ticker")
+	suite.Contains(properties, "startDate")
+	suite.Contains(properties, "endDate")
+	suite.Contains(properties, "interval")
+	suite.Contains(properties, "dataPath")
+
+	// Binance should not have apiKey in schema
+	suite.NotContains(properties, "apiKey")
+}

--- a/pkg/marketdata/provider_registry.go
+++ b/pkg/marketdata/provider_registry.go
@@ -1,0 +1,78 @@
+package marketdata
+
+import (
+	"fmt"
+
+	"github.com/rxtech-lab/argo-trading/pkg/strategy"
+)
+
+// ProviderInfo contains metadata about a market data provider.
+type ProviderInfo struct {
+	Name         string `json:"name"`
+	DisplayName  string `json:"displayName"`
+	Description  string `json:"description"`
+	RequiresAuth bool   `json:"requiresAuth"`
+}
+
+// providerRegistry holds metadata about all supported providers.
+var providerRegistry = map[ProviderType]ProviderInfo{
+	ProviderPolygon: {
+		Name:         string(ProviderPolygon),
+		DisplayName:  "Polygon.io",
+		Description:  "US stock market data provider with real-time and historical OHLCV data",
+		RequiresAuth: true,
+	},
+	ProviderBinance: {
+		Name:         string(ProviderBinance),
+		DisplayName:  "Binance",
+		Description:  "Cryptocurrency exchange with extensive market data for crypto trading pairs",
+		RequiresAuth: false,
+	},
+}
+
+// GetSupportedProviders returns a list of all supported provider names.
+func GetSupportedProviders() []string {
+	providers := make([]string, 0, len(providerRegistry))
+	for providerType := range providerRegistry {
+		providers = append(providers, string(providerType))
+	}
+
+	return providers
+}
+
+// GetProviderInfo returns metadata for a specific provider.
+func GetProviderInfo(providerName string) (ProviderInfo, error) {
+	info, exists := providerRegistry[ProviderType(providerName)]
+	if !exists {
+		return ProviderInfo{}, fmt.Errorf("unsupported provider: %s", providerName)
+	}
+
+	return info, nil
+}
+
+// GetDownloadConfigSchema returns the JSON schema for a provider's download configuration.
+func GetDownloadConfigSchema(providerName string) (string, error) {
+	switch ProviderType(providerName) {
+	case ProviderPolygon:
+		//nolint:exhaustruct // Empty struct is intentional for schema generation
+		return strategy.ToJSONSchema(PolygonDownloadConfig{})
+	case ProviderBinance:
+		//nolint:exhaustruct // Empty struct is intentional for schema generation
+		return strategy.ToJSONSchema(BinanceDownloadConfig{})
+	default:
+		return "", fmt.Errorf("unsupported provider: %s", providerName)
+	}
+}
+
+// ParseDownloadConfig parses a JSON configuration string for the given provider.
+// Returns the parsed config as an interface{} which can be type-asserted to the specific config type.
+func ParseDownloadConfig(providerName string, jsonConfig string) (interface{}, error) {
+	switch ProviderType(providerName) {
+	case ProviderPolygon:
+		return ParsePolygonConfig(jsonConfig)
+	case ProviderBinance:
+		return ParseBinanceConfig(jsonConfig)
+	default:
+		return nil, fmt.Errorf("unsupported provider: %s", providerName)
+	}
+}

--- a/pkg/marketdata/provider_registry_test.go
+++ b/pkg/marketdata/provider_registry_test.go
@@ -1,0 +1,162 @@
+package marketdata
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ProviderRegistryTestSuite struct {
+	suite.Suite
+}
+
+func TestProviderRegistryTestSuite(t *testing.T) {
+	suite.Run(t, new(ProviderRegistryTestSuite))
+}
+
+func (suite *ProviderRegistryTestSuite) TestGetSupportedProviders() {
+	providers := GetSupportedProviders()
+
+	suite.NotEmpty(providers)
+	suite.Contains(providers, "polygon")
+	suite.Contains(providers, "binance")
+	suite.Len(providers, 2)
+}
+
+func (suite *ProviderRegistryTestSuite) TestGetProviderInfo_Polygon() {
+	info, err := GetProviderInfo("polygon")
+
+	suite.NoError(err)
+	suite.Equal("polygon", info.Name)
+	suite.Equal("Polygon.io", info.DisplayName)
+	suite.True(info.RequiresAuth)
+	suite.NotEmpty(info.Description)
+}
+
+func (suite *ProviderRegistryTestSuite) TestGetProviderInfo_Binance() {
+	info, err := GetProviderInfo("binance")
+
+	suite.NoError(err)
+	suite.Equal("binance", info.Name)
+	suite.Equal("Binance", info.DisplayName)
+	suite.False(info.RequiresAuth)
+	suite.NotEmpty(info.Description)
+}
+
+func (suite *ProviderRegistryTestSuite) TestGetProviderInfo_InvalidProvider() {
+	_, err := GetProviderInfo("invalid")
+
+	suite.Error(err)
+	suite.Contains(err.Error(), "unsupported provider")
+}
+
+func (suite *ProviderRegistryTestSuite) TestGetDownloadConfigSchema_Polygon() {
+	schema, err := GetDownloadConfigSchema("polygon")
+
+	suite.NoError(err)
+	suite.NotEmpty(schema)
+
+	// Verify it's valid JSON
+	var schemaMap map[string]interface{}
+	err = json.Unmarshal([]byte(schema), &schemaMap)
+	suite.NoError(err)
+
+	// Verify schema has expected structure
+	suite.Contains(schemaMap, "properties")
+	suite.Contains(schemaMap, "type")
+	suite.Equal("object", schemaMap["type"])
+}
+
+func (suite *ProviderRegistryTestSuite) TestGetDownloadConfigSchema_Binance() {
+	schema, err := GetDownloadConfigSchema("binance")
+
+	suite.NoError(err)
+	suite.NotEmpty(schema)
+
+	// Verify it's valid JSON
+	var schemaMap map[string]interface{}
+	err = json.Unmarshal([]byte(schema), &schemaMap)
+	suite.NoError(err)
+
+	// Verify schema has expected structure
+	suite.Contains(schemaMap, "properties")
+	suite.Contains(schemaMap, "type")
+	suite.Equal("object", schemaMap["type"])
+}
+
+func (suite *ProviderRegistryTestSuite) TestGetDownloadConfigSchema_InvalidProvider() {
+	schema, err := GetDownloadConfigSchema("invalid")
+
+	suite.Error(err)
+	suite.Empty(schema)
+	suite.Contains(err.Error(), "unsupported provider")
+}
+
+func (suite *ProviderRegistryTestSuite) TestParseDownloadConfig_Polygon() {
+	jsonConfig := `{
+		"ticker": "SPY",
+		"startDate": "2024-01-01T00:00:00Z",
+		"endDate": "2024-12-31T23:59:59Z",
+		"interval": "1d",
+		"dataPath": "/tmp/data",
+		"apiKey": "test-api-key"
+	}`
+
+	config, err := ParseDownloadConfig("polygon", jsonConfig)
+
+	suite.NoError(err)
+	suite.NotNil(config)
+
+	polygonConfig, ok := config.(*PolygonDownloadConfig)
+	suite.True(ok)
+	suite.Equal("SPY", polygonConfig.Ticker)
+	suite.Equal("test-api-key", polygonConfig.ApiKey)
+}
+
+func (suite *ProviderRegistryTestSuite) TestParseDownloadConfig_Binance() {
+	jsonConfig := `{
+		"ticker": "BTCUSDT",
+		"startDate": "2024-01-01T00:00:00Z",
+		"endDate": "2024-12-31T23:59:59Z",
+		"interval": "1h",
+		"dataPath": "/tmp/data"
+	}`
+
+	config, err := ParseDownloadConfig("binance", jsonConfig)
+
+	suite.NoError(err)
+	suite.NotNil(config)
+
+	binanceConfig, ok := config.(*BinanceDownloadConfig)
+	suite.True(ok)
+	suite.Equal("BTCUSDT", binanceConfig.Ticker)
+}
+
+func (suite *ProviderRegistryTestSuite) TestParseDownloadConfig_InvalidProvider() {
+	jsonConfig := `{"ticker": "SPY"}`
+
+	_, err := ParseDownloadConfig("invalid", jsonConfig)
+
+	suite.Error(err)
+	suite.Contains(err.Error(), "unsupported provider")
+}
+
+func (suite *ProviderRegistryTestSuite) TestParseDownloadConfig_InvalidJSON() {
+	jsonConfig := `{invalid json}`
+
+	_, err := ParseDownloadConfig("polygon", jsonConfig)
+
+	suite.Error(err)
+	suite.Contains(err.Error(), "failed to parse JSON")
+}
+
+func (suite *ProviderRegistryTestSuite) TestParseDownloadConfig_MissingRequiredFields() {
+	jsonConfig := `{
+		"ticker": "SPY"
+	}`
+
+	_, err := ParseDownloadConfig("polygon", jsonConfig)
+
+	suite.Error(err)
+}

--- a/pkg/swift-argo/market_test.go
+++ b/pkg/swift-argo/market_test.go
@@ -1,11 +1,20 @@
 package swiftargo
 
 import (
+	"encoding/json"
 	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
+
+type MarketTestSuite struct {
+	suite.Suite
+}
+
+func TestMarketTestSuite(t *testing.T) {
+	suite.Run(t, new(MarketTestSuite))
+}
 
 // mockDownloaderHelper implements MarketDownloaderHelper for testing.
 type mockDownloaderHelper struct {
@@ -27,22 +36,146 @@ func (m *mockDownloaderHelper) OnDownloadProgress(current, total float64, messag
 	}{current, total, message})
 }
 
-func TestMarketDownloader_Cancel_NoDownloadInProgress(t *testing.T) {
-	helper := &mockDownloaderHelper{}
-	downloader := NewMarketDownloader(helper, "polygon", "duckdb", "/tmp", "test-key")
+func (suite *MarketTestSuite) TestGetSupportedDownloadClients() {
+	clients := GetSupportedDownloadClients()
 
-	// Cancel with no download in progress should return false
-	cancelled := downloader.Cancel()
-	assert.False(t, cancelled)
+	suite.NotNil(clients)
+	suite.GreaterOrEqual(clients.Size(), 2)
+
+	// Check that polygon and binance are in the list
+	found := make(map[string]bool)
+	for i := 0; i < clients.Size(); i++ {
+		found[clients.Get(i)] = true
+	}
+	suite.True(found["polygon"], "should contain polygon")
+	suite.True(found["binance"], "should contain binance")
 }
 
-func TestMarketDownloader_Cancel_ThreadSafety(t *testing.T) {
+func (suite *MarketTestSuite) TestGetDownloadClientSchema_Polygon() {
+	schema := GetDownloadClientSchema("polygon")
+
+	suite.NotEmpty(schema)
+
+	// Verify it's valid JSON
+	var schemaMap map[string]interface{}
+	err := json.Unmarshal([]byte(schema), &schemaMap)
+	suite.NoError(err)
+
+	// Check properties exist
+	properties, ok := schemaMap["properties"].(map[string]interface{})
+	suite.True(ok)
+	suite.Contains(properties, "ticker")
+	suite.Contains(properties, "apiKey")
+}
+
+func (suite *MarketTestSuite) TestGetDownloadClientSchema_Binance() {
+	schema := GetDownloadClientSchema("binance")
+
+	suite.NotEmpty(schema)
+
+	// Verify it's valid JSON
+	var schemaMap map[string]interface{}
+	err := json.Unmarshal([]byte(schema), &schemaMap)
+	suite.NoError(err)
+
+	// Check properties exist
+	properties, ok := schemaMap["properties"].(map[string]interface{})
+	suite.True(ok)
+	suite.Contains(properties, "ticker")
+	suite.NotContains(properties, "apiKey") // Binance doesn't need API key
+}
+
+func (suite *MarketTestSuite) TestGetDownloadClientSchema_InvalidProvider() {
+	schema := GetDownloadClientSchema("invalid")
+
+	suite.Empty(schema)
+}
+
+func (suite *MarketTestSuite) TestNewMarketDownloader() {
 	helper := &mockDownloaderHelper{}
-	downloader := NewMarketDownloader(helper, "polygon", "duckdb", "/tmp", "test-key")
+	downloader := NewMarketDownloader(helper)
 
-	// Simulate concurrent cancel calls - should not panic
+	suite.NotNil(downloader)
+	suite.NotNil(downloader.helper)
+}
+
+func (suite *MarketTestSuite) TestNewMarketDownloader_NilHelper() {
+	downloader := NewMarketDownloader(nil)
+
+	suite.NotNil(downloader)
+	suite.Nil(downloader.helper)
+}
+
+func (suite *MarketTestSuite) TestDownloadWithConfig_InvalidProvider() {
+	helper := &mockDownloaderHelper{}
+	downloader := NewMarketDownloader(helper)
+
+	err := downloader.DownloadWithConfig("invalid", `{}`)
+
+	suite.Error(err)
+	suite.Contains(err.Error(), "unsupported provider")
+}
+
+func (suite *MarketTestSuite) TestDownloadWithConfig_InvalidJSON() {
+	helper := &mockDownloaderHelper{}
+	downloader := NewMarketDownloader(helper)
+
+	err := downloader.DownloadWithConfig("polygon", `{invalid json}`)
+
+	suite.Error(err)
+	suite.Contains(err.Error(), "failed to parse")
+}
+
+func (suite *MarketTestSuite) TestDownloadWithConfig_MissingRequiredFields_Polygon() {
+	helper := &mockDownloaderHelper{}
+	downloader := NewMarketDownloader(helper)
+
+	// Missing apiKey
+	jsonConfig := `{
+		"ticker": "SPY",
+		"startDate": "2024-01-01T00:00:00Z",
+		"endDate": "2024-12-31T23:59:59Z",
+		"interval": "1d",
+		"dataPath": "/tmp/data"
+	}`
+
+	err := downloader.DownloadWithConfig("polygon", jsonConfig)
+
+	suite.Error(err)
+}
+
+func (suite *MarketTestSuite) TestDownloadWithConfig_MissingRequiredFields_Binance() {
+	helper := &mockDownloaderHelper{}
+	downloader := NewMarketDownloader(helper)
+
+	// Missing ticker
+	jsonConfig := `{
+		"startDate": "2024-01-01T00:00:00Z",
+		"endDate": "2024-12-31T23:59:59Z",
+		"interval": "1h",
+		"dataPath": "/tmp/data"
+	}`
+
+	err := downloader.DownloadWithConfig("binance", jsonConfig)
+
+	suite.Error(err)
+}
+
+func (suite *MarketTestSuite) TestCancel_NoDownloadInProgress() {
+	helper := &mockDownloaderHelper{}
+	downloader := NewMarketDownloader(helper)
+
+	cancelled := downloader.Cancel()
+
+	suite.False(cancelled)
+}
+
+func (suite *MarketTestSuite) TestCancelThreadSafety() {
+	helper := &mockDownloaderHelper{}
+	downloader := NewMarketDownloader(helper)
+
+	// Test that Cancel is safe to call concurrently
 	var wg sync.WaitGroup
-
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
@@ -50,18 +183,17 @@ func TestMarketDownloader_Cancel_ThreadSafety(t *testing.T) {
 			downloader.Cancel()
 		}()
 	}
-
 	wg.Wait()
-	// If we get here without panic, the test passes
+	// If we get here without panic, test passes
 }
 
-func TestNewMarketDownloader(t *testing.T) {
-	helper := &mockDownloaderHelper{}
-	downloader := NewMarketDownloader(helper, "polygon", "duckdb", "/tmp/data", "api-key-123")
+func (suite *MarketTestSuite) TestStringCollectionInterface() {
+	clients := GetSupportedDownloadClients()
 
-	assert.NotNil(t, downloader)
-	assert.Equal(t, "polygon", downloader.provider)
-	assert.Equal(t, "duckdb", downloader.writer)
-	assert.Equal(t, "/tmp/data", downloader.dataFolder)
-	assert.Equal(t, "api-key-123", downloader.polygonApiKey)
+	// Test Get with out of bounds index
+	suite.Empty(clients.Get(-1))
+	suite.Empty(clients.Get(100))
+
+	// Test Size
+	suite.Greater(clients.Size(), 0)
 }


### PR DESCRIPTION
- Introduced NewClientFromPolygonConfig and NewClientFromBinanceConfig functions for creating clients from respective configuration types.
- Added PolygonDownloadConfig and BinanceDownloadConfig structs with validation methods to ensure required fields are present.
- Implemented unit tests for configuration validation and parsing to enhance reliability and error handling.
- Established a provider registry for managing supported market data providers and their configurations.