### PR TITLE
feat: add GetIdentifier method to strategies and update stats to include id

### DIFF
--- a/e2e/backtest/wasm/multiple_data/multiple_data_test.go
+++ b/e2e/backtest/wasm/multiple_data/multiple_data_test.go
@@ -58,9 +58,13 @@ func (s *MultipleDataTestSuite) TestPlaceOrderStrategyWithMultipleData() {
 		s.Require().NoError(err)
 		s.Require().Equal(len(stats), 3)
 
-		// make sure each trade, num of trades > 0
+		// make sure each trade, num of trades > 0 and strategy metadata is present
 		for _, stat := range stats {
 			s.Require().Greater(stat.TradeResult.NumberOfTrades, 0)
+			// Verify strategy metadata is present in each stat
+			s.Require().Equal("com.argo-trading.e2e.place-order", stat.Strategy.ID)
+			s.Require().NotEmpty(stat.Strategy.Version)
+			s.Require().Equal("PlaceOrderStrategy", stat.Strategy.Name)
 		}
 	})
 }

--- a/e2e/backtest/wasm/place_fail_order/place_fail_order.go
+++ b/e2e/backtest/wasm/place_fail_order/place_fail_order.go
@@ -416,3 +416,10 @@ func (s *PlaceFailOrderStrategy) GetConfigSchema(_ context.Context, _ *strategy.
 	}
 	return &strategy.GetConfigSchemaResponse{Schema: schema}, nil
 }
+
+// GetIdentifier implements strategy.TradingStrategy.
+func (s *PlaceFailOrderStrategy) GetIdentifier(_ context.Context, _ *strategy.GetIdentifierRequest) (*strategy.GetIdentifierResponse, error) {
+	return &strategy.GetIdentifierResponse{
+		Identifier: "com.argo-trading.e2e.place-fail-order",
+	}, nil
+}

--- a/e2e/backtest/wasm/place_order/place_order.go
+++ b/e2e/backtest/wasm/place_order/place_order.go
@@ -125,3 +125,10 @@ func (s *PlaceOrderStrategy) GetConfigSchema(_ context.Context, _ *strategy.GetC
 	}
 	return &strategy.GetConfigSchemaResponse{Schema: schema}, nil
 }
+
+// GetIdentifier implements strategy.TradingStrategy.
+func (s *PlaceOrderStrategy) GetIdentifier(_ context.Context, _ *strategy.GetIdentifierRequest) (*strategy.GetIdentifierResponse, error) {
+	return &strategy.GetIdentifierResponse{
+		Identifier: "com.argo-trading.e2e.place-order",
+	}, nil
+}

--- a/e2e/backtest/wasm/place_order/place_order_test.go
+++ b/e2e/backtest/wasm/place_order/place_order_test.go
@@ -34,6 +34,11 @@ initial_capital: 10000
 		s.Require().Equal(stats[0].TradeResult.NumberOfTrades, 1)
 		s.Require().Equal(stats[0].Symbol, "AAPL")
 
+		// Verify strategy metadata is present in stats
+		s.Require().Equal("com.argo-trading.e2e.place-order", stats[0].Strategy.ID)
+		s.Require().NotEmpty(stats[0].Strategy.Version)
+		s.Require().Equal("PlaceOrderStrategy", stats[0].Strategy.Name)
+
 		// read trades
 		trades, err := testhelper.ReadTrades(&s.E2ETestSuite, tmpFolder)
 		s.Require().NoError(err)

--- a/e2e/backtest/wasm/sma/simple_ma_strategy.go
+++ b/e2e/backtest/wasm/sma/simple_ma_strategy.go
@@ -258,3 +258,10 @@ func (s *SimpleMAStrategy) GetConfigSchema(_ context.Context, _ *strategy.GetCon
 
 	return &strategy.GetConfigSchemaResponse{Schema: schema}, nil
 }
+
+// GetIdentifier implements strategy.TradingStrategy.
+func (s *SimpleMAStrategy) GetIdentifier(_ context.Context, _ *strategy.GetIdentifierRequest) (*strategy.GetIdentifierResponse, error) {
+	return &strategy.GetIdentifierResponse{
+		Identifier: "com.argo-trading.e2e.simple-ma",
+	}, nil
+}

--- a/examples/strategy/example_strategy.go
+++ b/examples/strategy/example_strategy.go
@@ -143,3 +143,10 @@ func (s *ConsecutiveCandlesStrategy) GetDescription(_ context.Context, _ *strate
 		Description: "A strategy that buys on 2 consecutive up candles and sells on 2 consecutive down candles",
 	}, nil
 }
+
+// GetIdentifier implements strategy.TradingStrategy.
+func (s *ConsecutiveCandlesStrategy) GetIdentifier(_ context.Context, _ *strategy.GetIdentifierRequest) (*strategy.GetIdentifierResponse, error) {
+	return &strategy.GetIdentifierResponse{
+		Identifier: "com.argo-trading.examples.consecutive-candles",
+	}, nil
+}

--- a/internal/backtest/engine/engine_v1/backtest_v1.go
+++ b/internal/backtest/engine/engine_v1/backtest_v1.go
@@ -512,7 +512,7 @@ func (b *BacktestEngineV1) runSingleIteration(params runIterationParams) error {
 		return errors.New(errors.ErrCodeBacktestStateNil, "backtest state is nil")
 	}
 
-	if err := b.writeResults(strategyContext, params.runID, params.resultFolderPath, params.strategyPath, params.dataPath); err != nil {
+	if err := b.writeResults(strategyContext, params.strategy, params.runID, params.resultFolderPath, params.strategyPath, params.dataPath); err != nil {
 		return errors.Wrap(errors.ErrCodeBacktestInitFailed, "failed to write results", err)
 	}
 
@@ -573,7 +573,7 @@ func (b *BacktestEngineV1) processDataPoints(params runIterationParams, strategy
 	return nil
 }
 
-func (b *BacktestEngineV1) writeResults(strategyContext runtime.RuntimeContext, runID string, resultFolderPath string, strategyPath string, dataPath string) error {
+func (b *BacktestEngineV1) writeResults(strategyContext runtime.RuntimeContext, strategyRuntime runtime.StrategyRuntime, runID string, resultFolderPath string, strategyPath string, dataPath string) error {
 	if b.state == nil {
 		return errors.New(errors.ErrCodeBacktestStateNil, "backtest state is nil")
 	}
@@ -584,7 +584,7 @@ func (b *BacktestEngineV1) writeResults(strategyContext runtime.RuntimeContext, 
 	ordersFilePath := filepath.Join(stateDBPath, "orders.parquet")
 	marksFilePath := filepath.Join(resultFolderPath, "marks.parquet")
 
-	stats, err := b.state.GetStats(strategyContext, runID, tradesFilePath, ordersFilePath, marksFilePath, strategyPath, dataPath)
+	stats, err := b.state.GetStats(strategyContext, strategyRuntime, runID, tradesFilePath, ordersFilePath, marksFilePath, strategyPath, dataPath)
 	if err != nil {
 		return errors.Wrap(errors.ErrCodeBacktestInitFailed, "failed to get stats", err)
 	}

--- a/internal/backtest/engine/engine_v1/backtest_v1_test.go
+++ b/internal/backtest/engine/engine_v1/backtest_v1_test.go
@@ -77,6 +77,7 @@ func TestBacktestEngineV1_Run(t *testing.T) {
 		mockStrategy.EXPECT().InitializeApi(gomock.Any()).Return(nil).AnyTimes()
 		mockStrategy.EXPECT().ProcessData(gomock.Any()).Return(nil).AnyTimes()
 		mockStrategy.EXPECT().GetRuntimeEngineVersion().Return("1.0.0", nil).AnyTimes()
+		mockStrategy.EXPECT().GetIdentifier().Return("com.test.mock", nil).AnyTimes()
 
 		// Setup datasource expectations - make sure Initialize ignores the path and returns nil
 		mockDatasource.EXPECT().Initialize(gomock.Any()).DoAndReturn(func(path string) error {
@@ -178,6 +179,7 @@ endTime: "2023-01-31T23:59:59Z"
 		mockStrategy.EXPECT().Initialize(gomock.Any()).Return(nil).AnyTimes()
 		mockStrategy.EXPECT().InitializeApi(gomock.Any()).Return(nil).AnyTimes()
 		mockStrategy.EXPECT().GetRuntimeEngineVersion().Return("1.0.0", nil).AnyTimes()
+		mockStrategy.EXPECT().GetIdentifier().Return("com.test.mock", nil).AnyTimes()
 
 		// Important: expect ProcessData to be called with exact data points in order
 		gomock.InOrder(
@@ -265,6 +267,7 @@ endTime: "2023-01-31T23:59:59Z"
 			return nil
 		}).AnyTimes()
 		mockStrategy.EXPECT().GetRuntimeEngineVersion().Return("1.0.0", nil).AnyTimes()
+		mockStrategy.EXPECT().GetIdentifier().Return("com.test.mock", nil).AnyTimes()
 
 		// Setup datasource expectations - make sure Initialize ignores the path and returns nil
 		mockDatasource.EXPECT().Initialize(gomock.Any()).DoAndReturn(func(path string) error {
@@ -365,6 +368,7 @@ endTime: "2023-01-31T23:59:59Z"
 		mockStrategy.EXPECT().InitializeApi(gomock.Any()).Return(nil).AnyTimes()
 		mockStrategy.EXPECT().ProcessData(gomock.Any()).Return(nil).AnyTimes()
 		mockStrategy.EXPECT().GetRuntimeEngineVersion().Return("1.0.0", nil).AnyTimes()
+		mockStrategy.EXPECT().GetIdentifier().Return("com.test.mock", nil).AnyTimes()
 
 		// Setup datasource expectations - make sure Initialize ignores the path and returns nil
 		mockDatasource.EXPECT().Initialize(gomock.Any()).DoAndReturn(func(path string) error {
@@ -703,6 +707,7 @@ func TestBacktestEngineV1_SetConfigContent(t *testing.T) {
 		mockStrategy.EXPECT().Initialize(gomock.Any()).Return(nil).AnyTimes()
 		mockStrategy.EXPECT().ProcessData(gomock.Any()).Return(nil).AnyTimes()
 		mockStrategy.EXPECT().GetRuntimeEngineVersion().Return("1.0.0", nil).AnyTimes()
+		mockStrategy.EXPECT().GetIdentifier().Return("com.test.mock", nil).AnyTimes()
 
 		mockDatasource.EXPECT().Initialize(gomock.Any()).Return(nil).AnyTimes()
 		mockDatasource.EXPECT().Count(gomock.Any(), gomock.Any()).Return(1, nil).AnyTimes()
@@ -774,6 +779,7 @@ func TestBacktestEngineV1_SetConfigContent(t *testing.T) {
 		mockStrategy.EXPECT().Initialize(`{"config": 2}`).Return(nil).Times(1)
 		mockStrategy.EXPECT().ProcessData(gomock.Any()).Return(nil).AnyTimes()
 		mockStrategy.EXPECT().GetRuntimeEngineVersion().Return("1.0.0", nil).AnyTimes()
+		mockStrategy.EXPECT().GetIdentifier().Return("com.test.mock", nil).AnyTimes()
 
 		mockDatasource.EXPECT().Initialize(gomock.Any()).Return(nil).AnyTimes()
 		mockDatasource.EXPECT().Count(gomock.Any(), gomock.Any()).Return(1, nil).AnyTimes()
@@ -1248,6 +1254,7 @@ func TestBacktestEngineV1_RunErrors(t *testing.T) {
 		mockStrategy.EXPECT().Initialize(gomock.Any()).Return(nil).AnyTimes()
 		mockStrategy.EXPECT().ProcessData(gomock.Any()).Return(nil).AnyTimes()
 		mockStrategy.EXPECT().GetRuntimeEngineVersion().Return("1.0.0", nil).AnyTimes()
+		mockStrategy.EXPECT().GetIdentifier().Return("com.test.mock", nil).AnyTimes()
 
 		mockDatasource.EXPECT().Initialize(gomock.Any()).Return(nil).AnyTimes()
 		mockDatasource.EXPECT().Count(gomock.Any(), gomock.Any()).Return(2, nil).AnyTimes()
@@ -1311,6 +1318,7 @@ func TestLifecycleCallbacks(t *testing.T) {
 		mockStrategy.EXPECT().Initialize(gomock.Any()).Return(nil).AnyTimes()
 		mockStrategy.EXPECT().ProcessData(gomock.Any()).Return(nil).AnyTimes()
 		mockStrategy.EXPECT().GetRuntimeEngineVersion().Return("1.0.0", nil).AnyTimes()
+		mockStrategy.EXPECT().GetIdentifier().Return("com.test.mock", nil).AnyTimes()
 
 		mockDatasource.EXPECT().Initialize(gomock.Any()).Return(nil).AnyTimes()
 		mockDatasource.EXPECT().Count(gomock.Any(), gomock.Any()).Return(2, nil).AnyTimes()

--- a/internal/backtest/engine/engine_v1/state_test.go
+++ b/internal/backtest/engine/engine_v1/state_test.go
@@ -13,9 +13,22 @@ import (
 	"github.com/rxtech-lab/argo-trading/internal/runtime"
 	"github.com/rxtech-lab/argo-trading/internal/types"
 	"github.com/rxtech-lab/argo-trading/mocks"
+	"github.com/rxtech-lab/argo-trading/pkg/strategy"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 )
+
+// testMockStrategyRuntime is a mock implementation of StrategyRuntime for state tests
+type testMockStrategyRuntime struct{}
+
+func (m *testMockStrategyRuntime) Initialize(config string) error               { return nil }
+func (m *testMockStrategyRuntime) InitializeApi(api strategy.StrategyApi) error { return nil }
+func (m *testMockStrategyRuntime) ProcessData(data types.MarketData) error      { return nil }
+func (m *testMockStrategyRuntime) GetConfigSchema() (string, error)             { return "", nil }
+func (m *testMockStrategyRuntime) Name() string                                 { return "TestStrategy" }
+func (m *testMockStrategyRuntime) GetDescription() (string, error)              { return "Test", nil }
+func (m *testMockStrategyRuntime) GetRuntimeEngineVersion() (string, error)     { return "1.0.0", nil }
+func (m *testMockStrategyRuntime) GetIdentifier() (string, error)               { return "com.test.state-test", nil }
 
 // BacktestStateTestSuite is a test suite for BacktestState
 type BacktestStateTestSuite struct {
@@ -734,9 +747,10 @@ func (suite *BacktestStateTestSuite) TestGetStats() {
 			}
 
 			// Get stats
+			mockStrategy := &testMockStrategyRuntime{}
 			stats, err := suite.state.GetStats(runtime.RuntimeContext{
 				DataSource: mockSource,
-			}, "test-run-id", "/path/to/trades.parquet", "/path/to/orders.parquet", "/path/to/marks.parquet", "/path/to/strategy.wasm", "/path/to/data.parquet")
+			}, mockStrategy, "test-run-id", "/path/to/trades.parquet", "/path/to/orders.parquet", "/path/to/marks.parquet", "/path/to/strategy.wasm", "/path/to/data.parquet")
 			if tc.expectError {
 				suite.Assert().Error(err)
 				return

--- a/internal/backtest/engine/engine_v1/utils_test.go
+++ b/internal/backtest/engine/engine_v1/utils_test.go
@@ -45,6 +45,10 @@ func (m *MockStrategy) GetRuntimeEngineVersion() (string, error) {
 	return "1.0.0", nil
 }
 
+func (m *MockStrategy) GetIdentifier() (string, error) {
+	return "com.test.mock-strategy", nil
+}
+
 // UtilsTestSuite is a test suite for utils package
 type UtilsTestSuite struct {
 	suite.Suite

--- a/internal/backtest/engine/engine_v1/version_test.go
+++ b/internal/backtest/engine/engine_v1/version_test.go
@@ -46,6 +46,10 @@ func (m *mockStrategyRuntime) GetRuntimeEngineVersion() (string, error) {
 	return m.runtimeVersion, nil
 }
 
+func (m *mockStrategyRuntime) GetIdentifier() (string, error) {
+	return "com.test.mock-strategy", nil
+}
+
 func TestVersionCompatibilityCheck(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/internal/runtime/go/go_runtime.go
+++ b/internal/runtime/go/go_runtime.go
@@ -47,6 +47,11 @@ func (g *GoRuntime) GetRuntimeEngineVersion() (string, error) {
 	panic("unimplemented")
 }
 
+// GetIdentifier implements StrategyRuntime.
+func (g *GoRuntime) GetIdentifier() (string, error) {
+	panic("unimplemented")
+}
+
 func NewGoRuntime(strategy runtime.StrategyRuntime) runtime.StrategyRuntime {
 	return &GoRuntime{
 		strategy: strategy,

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -26,6 +26,8 @@ type StrategyRuntime interface {
 	GetDescription() (string, error)
 	// GetRuntimeEngineVersion returns the engine version the strategy was compiled against
 	GetRuntimeEngineVersion() (string, error)
+	// GetIdentifier returns the unique identifier for the strategy (e.g., "com.example.strategy")
+	GetIdentifier() (string, error)
 }
 
 type RuntimeContext struct {

--- a/internal/runtime/wasm/wasm.go
+++ b/internal/runtime/wasm/wasm.go
@@ -158,6 +158,26 @@ func (s *StrategyWasmRuntime) GetRuntimeEngineVersion() (string, error) {
 	return "", nil
 }
 
+// GetIdentifier returns the unique identifier for the strategy (e.g., "com.example.strategy").
+// This method is required - strategies that don't implement it will fail to load.
+func (s *StrategyWasmRuntime) GetIdentifier() (string, error) {
+	if s.strategy == nil {
+		return "", errors.New(errors.ErrCodeStrategyNotLoaded, "strategy is not initialized, call InitializeApi first")
+	}
+
+	identifier, err := s.strategy.GetIdentifier(context.Background(), &strategy.GetIdentifierRequest{})
+	if err != nil {
+		return "", errors.Wrap(errors.ErrCodeStrategyRuntimeError, "failed to get strategy identifier", err)
+	}
+
+	// Validate required field
+	if identifier.Identifier == "" {
+		return "", errors.New(errors.ErrCodeInvalidConfiguration, "strategy identifier is required but was empty")
+	}
+
+	return identifier.Identifier, nil
+}
+
 func (s *StrategyWasmRuntime) loadPlugin(ctx context.Context, api strategy.StrategyApi) (strategy.TradingStrategy, error) {
 	p, err := strategy.NewTradingStrategyPlugin(ctx)
 	if err != nil {

--- a/internal/types/statistics.go
+++ b/internal/types/statistics.go
@@ -43,6 +43,16 @@ type TradeResult struct {
 	MaxDrawdown float64 `yaml:"max_drawdown"`
 }
 
+// StrategyInfo contains metadata about the strategy that generated stats.
+type StrategyInfo struct {
+	// ID is the unique identifier for the strategy (e.g., "com.example.strategy.sma")
+	ID string `yaml:"id" json:"id"`
+	// Version is the version of the strategy (from GetRuntimeEngineVersion)
+	Version string `yaml:"version" json:"version"`
+	// Name is the human-readable name of the strategy
+	Name string `yaml:"name" json:"name"`
+}
+
 type TradeStats struct {
 	// ID is the unique identifier for this backtest run.
 	ID string `yaml:"id" json:"id"`
@@ -66,6 +76,8 @@ type TradeStats struct {
 	OrdersFilePath string `yaml:"orders_file_path" json:"orders_file_path"`
 	// MarksFilePath is the path to the marks parquet file.
 	MarksFilePath string `yaml:"marks_file_path" json:"marks_file_path"`
+	// Strategy contains metadata about the strategy that generated these stats.
+	Strategy StrategyInfo `yaml:"strategy" json:"strategy"`
 	// StrategyPath is the path to the strategy WASM file.
 	StrategyPath string `yaml:"strategy_path" json:"strategy_path"`
 	// DataPath is the path to the market data file used for this backtest.

--- a/pkg/strategy/strategy.pb.go
+++ b/pkg/strategy/strategy.pb.go
@@ -612,6 +612,38 @@ func (x *NameResponse) GetName() string {
 	return ""
 }
 
+// GetIdentifierRequest is an empty request for getting the strategy identifier
+type GetIdentifierRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+}
+
+func (x *GetIdentifierRequest) ProtoReflect() protoreflect.Message {
+	panic(`not implemented`)
+}
+
+// GetIdentifierResponse contains the strategy identifier
+type GetIdentifierResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// Unique identifier for the strategy (e.g., "com.example.strategy.sma")
+	Identifier string `protobuf:"bytes,1,opt,name=identifier,proto3" json:"identifier,omitempty"`
+}
+
+func (x *GetIdentifierResponse) ProtoReflect() protoreflect.Message {
+	panic(`not implemented`)
+}
+
+func (x *GetIdentifierResponse) GetIdentifier() string {
+	if x != nil {
+		return x.Identifier
+	}
+	return ""
+}
+
 type GetRangeRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1948,6 +1980,8 @@ type TradingStrategy interface {
 	GetConfigSchema(context.Context, *GetConfigSchemaRequest) (*GetConfigSchemaResponse, error)
 	// GetDescription returns a description of the strategy
 	GetDescription(context.Context, *GetDescriptionRequest) (*GetDescriptionResponse, error)
+	// GetIdentifier returns the unique identifier for the strategy (e.g., "com.example.strategy")
+	GetIdentifier(context.Context, *GetIdentifierRequest) (*GetIdentifierResponse, error)
 }
 
 // StrategyApi defines all the functions that the host provides to the plugin

--- a/pkg/strategy/strategy.proto
+++ b/pkg/strategy/strategy.proto
@@ -31,6 +31,8 @@ service TradingStrategy {
   rpc GetConfigSchema(GetConfigSchemaRequest) returns (GetConfigSchemaResponse) {}
   // GetDescription returns a description of the strategy
   rpc GetDescription(GetDescriptionRequest) returns (GetDescriptionResponse) {}
+  // GetIdentifier returns the unique identifier for the strategy (e.g., "com.example.strategy")
+  rpc GetIdentifier(GetIdentifierRequest) returns (GetIdentifierResponse) {}
 }
 
 message GetConfigSchemaRequest {}
@@ -61,6 +63,15 @@ message NameRequest {}
 // NameResponse contains the strategy name
 message NameResponse {
   string name = 1;
+}
+
+// GetIdentifierRequest is an empty request for getting the strategy identifier
+message GetIdentifierRequest {}
+
+// GetIdentifierResponse contains the strategy identifier
+message GetIdentifierResponse {
+  // Unique identifier for the strategy (e.g., "com.example.strategy.sma")
+  string identifier = 1;
 }
 
 // StrategyApi defines all the functions that the host provides to the plugin

--- a/pkg/strategy/strategy_host.pb.go
+++ b/pkg/strategy/strategy_host.pb.go
@@ -820,6 +820,10 @@ func (p *TradingStrategyPlugin) Load(ctx context.Context, pluginPath string, hos
 	if getdescription == nil {
 		return nil, errors.New("trading_strategy_get_description is not exported")
 	}
+	getidentifier := module.ExportedFunction("trading_strategy_get_identifier")
+	if getidentifier == nil {
+		return nil, errors.New("trading_strategy_get_identifier is not exported")
+	}
 
 	malloc := module.ExportedFunction("malloc")
 	if malloc == nil {
@@ -840,6 +844,7 @@ func (p *TradingStrategyPlugin) Load(ctx context.Context, pluginPath string, hos
 		name:            name,
 		getconfigschema: getconfigschema,
 		getdescription:  getdescription,
+		getidentifier:   getidentifier,
 	}, nil
 }
 
@@ -860,6 +865,7 @@ type tradingStrategyPlugin struct {
 	name            api.Function
 	getconfigschema api.Function
 	getdescription  api.Function
+	getidentifier   api.Function
 }
 
 func (p *tradingStrategyPlugin) Initialize(ctx context.Context, request *InitializeRequest) (*emptypb.Empty, error) {
@@ -1161,6 +1167,67 @@ func (p *tradingStrategyPlugin) GetDescription(ctx context.Context, request *Get
 	}
 
 	response := new(GetDescriptionResponse)
+	if err = response.UnmarshalVT(bytes); err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+func (p *tradingStrategyPlugin) GetIdentifier(ctx context.Context, request *GetIdentifierRequest) (*GetIdentifierResponse, error) {
+	data, err := request.MarshalVT()
+	if err != nil {
+		return nil, err
+	}
+	dataSize := uint64(len(data))
+
+	var dataPtr uint64
+	// If the input data is not empty, we must allocate the in-Wasm memory to store it, and pass to the plugin.
+	if dataSize != 0 {
+		results, err := p.malloc.Call(ctx, dataSize)
+		if err != nil {
+			return nil, err
+		}
+		dataPtr = results[0]
+		// This pointer is managed by the Wasm module, which is unaware of external usage.
+		// So, we have to free it when finished
+		defer p.free.Call(ctx, dataPtr)
+
+		// The pointer is a linear memory offset, which is where we write the name.
+		if !p.module.Memory().Write(uint32(dataPtr), data) {
+			return nil, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size())
+		}
+	}
+
+	ptrSize, err := p.getidentifier.Call(ctx, dataPtr, dataSize)
+	if err != nil {
+		return nil, err
+	}
+
+	resPtr := uint32(ptrSize[0] >> 32)
+	resSize := uint32(ptrSize[0])
+	var isErrResponse bool
+	if (resSize & (1 << 31)) > 0 {
+		isErrResponse = true
+		resSize &^= (1 << 31)
+	}
+
+	// We don't need the memory after deserialization: make sure it is freed.
+	if resPtr != 0 {
+		defer p.free.Call(ctx, uint64(resPtr))
+	}
+
+	// The pointer is a linear memory offset, which is where we write the name.
+	bytes, ok := p.module.Memory().Read(resPtr, resSize)
+	if !ok {
+		return nil, fmt.Errorf("Memory.Read(%d, %d) out of range of memory size %d",
+			resPtr, resSize, p.module.Memory().Size())
+	}
+
+	if isErrResponse {
+		return nil, errors.New(string(bytes))
+	}
+
+	response := new(GetIdentifierResponse)
 	if err = response.UnmarshalVT(bytes); err != nil {
 		return nil, err
 	}

--- a/pkg/strategy/strategy_plugin.pb.go
+++ b/pkg/strategy/strategy_plugin.pb.go
@@ -148,6 +148,30 @@ func _trading_strategy_get_description(ptr, size uint32) uint64 {
 	return (uint64(ptr) << uint64(32)) | uint64(size)
 }
 
+//go:wasmexport trading_strategy_get_identifier
+func _trading_strategy_get_identifier(ptr, size uint32) uint64 {
+	b := wasm.PtrToByte(ptr, size)
+	req := new(GetIdentifierRequest)
+	if err := req.UnmarshalVT(b); err != nil {
+		return 0
+	}
+	response, err := tradingStrategy.GetIdentifier(context.Background(), req)
+	if err != nil {
+		ptr, size = wasm.ByteToPtr([]byte(err.Error()))
+		return (uint64(ptr) << uint64(32)) | uint64(size) |
+			// Indicate that this is the error string by setting the 32-th bit, assuming that
+			// no data exceeds 31-bit size (2 GiB).
+			(1 << 31)
+	}
+
+	b, err = response.MarshalVT()
+	if err != nil {
+		return 0
+	}
+	ptr, size = wasm.ByteToPtr(b)
+	return (uint64(ptr) << uint64(32)) | uint64(size)
+}
+
 type strategyApi struct{}
 
 func NewStrategyApi() StrategyApi {

--- a/pkg/strategy/strategy_vtproto.pb.go
+++ b/pkg/strategy/strategy_vtproto.pb.go
@@ -418,6 +418,79 @@ func (m *NameResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *GetIdentifierRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetIdentifierRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *GetIdentifierRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetIdentifierResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetIdentifierResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *GetIdentifierResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Identifier) > 0 {
+		i -= len(m.Identifier)
+		copy(dAtA[i:], m.Identifier)
+		i = encodeVarint(dAtA, i, uint64(len(m.Identifier)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *GetRangeRequest) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -2705,6 +2778,30 @@ func (m *NameResponse) SizeVT() (n int) {
 	return n
 }
 
+func (m *GetIdentifierRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *GetIdentifierResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Identifier)
+	if l > 0 {
+		n += 1 + l + sov(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *GetRangeRequest) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -4291,6 +4388,140 @@ func (m *NameResponse) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetIdentifierRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetIdentifierRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetIdentifierRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetIdentifierResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetIdentifierResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetIdentifierResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Identifier", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Identifier = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/swift-argo/strategy.go
+++ b/pkg/swift-argo/strategy.go
@@ -6,6 +6,7 @@ import (
 
 // StrategyMetadata contains the metadata of a trading strategy.
 type StrategyMetadata struct {
+	Identifier     string
 	Name           string
 	Schema         string
 	Description    string
@@ -47,10 +48,16 @@ func (s *StrategyApi) GetStrategyMetadata(path string) (*StrategyMetadata, error
 		return nil, err
 	}
 
+	identifier, err := runtime.GetIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
 	return &StrategyMetadata{
 		Name:           runtime.Name(),
 		Schema:         schema,
 		Description:    description,
 		RuntimeVersion: runtimeVersion,
+		Identifier:     identifier,
 	}, nil
 }


### PR DESCRIPTION
- Implemented GetIdentifier method in various strategy types to return unique identifiers.
- Updated GetStats method to include strategy metadata (ID, version, name) in the returned statistics.
- Enhanced test cases to verify the presence of strategy metadata in order statistics.