### PR TITLE
perf: add InMemoryIndexedDataSource for 10x+ backtest performance

### DIFF
--- a/internal/backtest/engine/engine_v1/datasource/benchmark_test.go
+++ b/internal/backtest/engine/engine_v1/datasource/benchmark_test.go
@@ -1,0 +1,391 @@
+package datasource
+
+import (
+	"testing"
+	"time"
+
+	"github.com/moznion/go-optional"
+	"github.com/rxtech-lab/argo-trading/internal/logger"
+	"github.com/rxtech-lab/argo-trading/internal/types"
+	"github.com/rxtech-lab/argo-trading/mocks"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+// createTestLogger creates a silent logger for benchmarks
+func createTestLogger() *logger.Logger {
+	loggerConfig := zap.NewDevelopmentConfig()
+	loggerConfig.OutputPaths = []string{}
+	loggerConfig.ErrorOutputPaths = []string{}
+	zapLogger, _ := loggerConfig.Build()
+	return &logger.Logger{Logger: zapLogger}
+}
+
+// setupBenchmarkData creates a DuckDB datasource with generated test data
+func setupBenchmarkData(b *testing.B, count int) (DataSource, []types.MarketData) {
+	log := createTestLogger()
+
+	// Generate test data
+	gen := mocks.NewDataGenerator(42)
+	config := mocks.DefaultConfig()
+	config.Symbol = "TEST"
+	config.Count = count
+	data := gen.Generate(config)
+
+	// Create in-memory DuckDB datasource
+	ds, err := NewDataSource(":memory:", log)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Create table and insert data manually for benchmarks
+	db := ds.(*DuckDBDataSource).db
+	_, err = db.Exec(`
+		CREATE TABLE market_data (
+			time TIMESTAMP,
+			symbol VARCHAR,
+			open DOUBLE,
+			high DOUBLE,
+			low DOUBLE,
+			close DOUBLE,
+			volume DOUBLE
+		);
+	`)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Insert data in batches for efficiency
+	stmt, err := db.Prepare(`INSERT INTO market_data VALUES ($1, $2, $3, $4, $5, $6, $7)`)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for _, md := range data {
+		_, err = stmt.Exec(md.Time, md.Symbol, md.Open, md.High, md.Low, md.Close, md.Volume)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	stmt.Close()
+
+	// Create index
+	_, err = db.Exec(`CREATE INDEX idx_market_data_symbol_time ON market_data(symbol, time);`)
+	if err != nil {
+		b.Logf("Warning: could not create index: %v", err)
+	}
+
+	return ds, data
+}
+
+// BenchmarkDuckDBGetPreviousDataPoints benchmarks DuckDB queries for historical data
+func BenchmarkDuckDBGetPreviousDataPoints(b *testing.B) {
+	counts := []int{100, 1000, 10000}
+
+	for _, count := range counts {
+		b.Run(formatCount(count), func(b *testing.B) {
+			ds, data := setupBenchmarkData(b, count)
+			defer ds.Close()
+
+			// Use a point in the middle of the data for queries
+			midIdx := len(data) / 2
+			midTime := data[midIdx].Time
+			symbol := "TEST"
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := ds.GetPreviousNumberOfDataPoints(midTime, symbol, 26)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkInMemoryIndexedGetPreviousDataPoints benchmarks in-memory indexed lookups
+func BenchmarkInMemoryIndexedGetPreviousDataPoints(b *testing.B) {
+	counts := []int{100, 1000, 10000}
+
+	for _, count := range counts {
+		b.Run(formatCount(count), func(b *testing.B) {
+			ds, data := setupBenchmarkData(b, count)
+			defer ds.Close()
+
+			// Wrap with in-memory indexed datasource and preload
+			indexedDS := NewInMemoryIndexedDataSource(ds)
+			err := indexedDS.Preload(optional.None[time.Time](), optional.None[time.Time]())
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			// Use a point in the middle of the data for queries
+			midIdx := len(data) / 2
+			midTime := data[midIdx].Time
+			symbol := "TEST"
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := indexedDS.GetPreviousNumberOfDataPoints(midTime, symbol, 26)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkInMemoryIndexedGetPreviousNBars benchmarks direct bar-indexed lookups (fastest)
+func BenchmarkInMemoryIndexedGetPreviousNBars(b *testing.B) {
+	counts := []int{100, 1000, 10000}
+
+	for _, count := range counts {
+		b.Run(formatCount(count), func(b *testing.B) {
+			ds, _ := setupBenchmarkData(b, count)
+			defer ds.Close()
+
+			// Wrap with in-memory indexed datasource and preload
+			indexedDS := NewInMemoryIndexedDataSource(ds)
+			err := indexedDS.Preload(optional.None[time.Time](), optional.None[time.Time]())
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			// Set current bar index to middle of data
+			midIdx := count / 2
+			indexedDS.SetCurrentBarIndex(midIdx)
+			symbol := "TEST"
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := indexedDS.GetPreviousNBars(symbol, 26)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkReadAllComparison compares ReadAll performance
+func BenchmarkReadAllComparison(b *testing.B) {
+	b.Run("DuckDB_10k", func(b *testing.B) {
+		ds, _ := setupBenchmarkData(b, 10000)
+		defer ds.Close()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			count := 0
+			for _, err := range ds.ReadAll(optional.None[time.Time](), optional.None[time.Time]()) {
+				if err != nil {
+					b.Fatal(err)
+				}
+				count++
+			}
+			if count != 10000 {
+				b.Fatalf("expected 10000 records, got %d", count)
+			}
+		}
+	})
+
+	b.Run("InMemoryIndexed_10k", func(b *testing.B) {
+		ds, _ := setupBenchmarkData(b, 10000)
+		defer ds.Close()
+
+		indexedDS := NewInMemoryIndexedDataSource(ds)
+		err := indexedDS.Preload(optional.None[time.Time](), optional.None[time.Time]())
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			count := 0
+			for _, err := range indexedDS.ReadAll(optional.None[time.Time](), optional.None[time.Time]()) {
+				if err != nil {
+					b.Fatal(err)
+				}
+				count++
+			}
+			if count != 10000 {
+				b.Fatalf("expected 10000 records, got %d", count)
+			}
+		}
+	})
+}
+
+// BenchmarkMultipleIndicatorQueries simulates indicator calculation pattern
+func BenchmarkMultipleIndicatorQueries(b *testing.B) {
+	// Indicator calculation typically queries multiple periods: 12, 14, 20, 26
+	periods := []int{12, 14, 20, 26}
+
+	b.Run("DuckDB_10k", func(b *testing.B) {
+		ds, data := setupBenchmarkData(b, 10000)
+		defer ds.Close()
+
+		midIdx := len(data) / 2
+		midTime := data[midIdx].Time
+		symbol := "TEST"
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for _, period := range periods {
+				_, err := ds.GetPreviousNumberOfDataPoints(midTime, symbol, period)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	})
+
+	b.Run("InMemoryIndexed_10k", func(b *testing.B) {
+		ds, data := setupBenchmarkData(b, 10000)
+		defer ds.Close()
+
+		indexedDS := NewInMemoryIndexedDataSource(ds)
+		err := indexedDS.Preload(optional.None[time.Time](), optional.None[time.Time]())
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		midIdx := len(data) / 2
+		midTime := data[midIdx].Time
+		symbol := "TEST"
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for _, period := range periods {
+				_, err := indexedDS.GetPreviousNumberOfDataPoints(midTime, symbol, period)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	})
+
+	b.Run("InMemoryIndexedNBars_10k", func(b *testing.B) {
+		ds, _ := setupBenchmarkData(b, 10000)
+		defer ds.Close()
+
+		indexedDS := NewInMemoryIndexedDataSource(ds)
+		err := indexedDS.Preload(optional.None[time.Time](), optional.None[time.Time]())
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		midIdx := 5000
+		indexedDS.SetCurrentBarIndex(midIdx)
+		symbol := "TEST"
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for _, period := range periods {
+				_, err := indexedDS.GetPreviousNBars(symbol, period)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	})
+}
+
+// TestPerformanceImprovement verifies that in-memory indexing provides significant speedup
+func TestPerformanceImprovement(t *testing.T) {
+	log := createTestLogger()
+
+	// Generate 10k test data
+	gen := mocks.NewDataGenerator(42)
+	config := mocks.DefaultConfig()
+	config.Symbol = "TEST"
+	config.Count = 10000
+	data := gen.Generate(config)
+
+	// Create in-memory DuckDB datasource
+	ds, err := NewDataSource(":memory:", log)
+	assert.NoError(t, err)
+	defer ds.Close()
+
+	// Create table and insert data
+	db := ds.(*DuckDBDataSource).db
+	_, err = db.Exec(`
+		CREATE TABLE market_data (
+			time TIMESTAMP,
+			symbol VARCHAR,
+			open DOUBLE,
+			high DOUBLE,
+			low DOUBLE,
+			close DOUBLE,
+			volume DOUBLE
+		);
+	`)
+	assert.NoError(t, err)
+
+	stmt, err := db.Prepare(`INSERT INTO market_data VALUES ($1, $2, $3, $4, $5, $6, $7)`)
+	assert.NoError(t, err)
+
+	for _, md := range data {
+		_, err = stmt.Exec(md.Time, md.Symbol, md.Open, md.High, md.Low, md.Close, md.Volume)
+		assert.NoError(t, err)
+	}
+	stmt.Close()
+
+	// Create index
+	_, _ = db.Exec(`CREATE INDEX idx_market_data_symbol_time ON market_data(symbol, time);`)
+
+	// Create in-memory indexed datasource and preload
+	indexedDS := NewInMemoryIndexedDataSource(ds)
+	err = indexedDS.Preload(optional.None[time.Time](), optional.None[time.Time]())
+	assert.NoError(t, err)
+
+	midIdx := len(data) / 2
+	midTime := data[midIdx].Time
+	symbol := "TEST"
+	iterations := 1000
+
+	// Measure DuckDB query time
+	duckDBStart := time.Now()
+	for i := 0; i < iterations; i++ {
+		_, err := ds.GetPreviousNumberOfDataPoints(midTime, symbol, 26)
+		assert.NoError(t, err)
+	}
+	duckDBDuration := time.Since(duckDBStart)
+
+	// Measure in-memory indexed query time
+	indexedStart := time.Now()
+	for i := 0; i < iterations; i++ {
+		_, err := indexedDS.GetPreviousNumberOfDataPoints(midTime, symbol, 26)
+		assert.NoError(t, err)
+	}
+	indexedDuration := time.Since(indexedStart)
+
+	// Measure direct bar-indexed query time
+	indexedDS.SetCurrentBarIndex(midIdx)
+	barIndexedStart := time.Now()
+	for i := 0; i < iterations; i++ {
+		_, err := indexedDS.GetPreviousNBars(symbol, 26)
+		assert.NoError(t, err)
+	}
+	barIndexedDuration := time.Since(barIndexedStart)
+
+	speedup := float64(duckDBDuration) / float64(indexedDuration)
+	barSpeedup := float64(duckDBDuration) / float64(barIndexedDuration)
+
+	t.Logf("Performance comparison (10k data, %d iterations):", iterations)
+	t.Logf("  DuckDB queries:          %v", duckDBDuration)
+	t.Logf("  In-memory indexed:       %v (%.1fx faster)", indexedDuration, speedup)
+	t.Logf("  Direct bar-indexed:      %v (%.1fx faster)", barIndexedDuration, barSpeedup)
+
+	// Assert at least 10x improvement for direct bar-indexed access
+	assert.Greater(t, barSpeedup, 10.0, "Expected at least 10x performance improvement with bar-indexed access")
+}
+
+func formatCount(count int) string {
+	switch {
+	case count >= 10000:
+		return "10k"
+	case count >= 1000:
+		return "1k"
+	default:
+		return "100"
+	}
+}

--- a/internal/backtest/engine/engine_v1/datasource/in_memory_indexed_datasource.go
+++ b/internal/backtest/engine/engine_v1/datasource/in_memory_indexed_datasource.go
@@ -1,0 +1,466 @@
+package datasource
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/moznion/go-optional"
+	"github.com/rxtech-lab/argo-trading/internal/types"
+	"github.com/rxtech-lab/argo-trading/pkg/errors"
+)
+
+// InMemoryIndexedDataSource provides high-performance indexed access to market data.
+// It preloads all data into memory and uses array indexing for O(1) lookups,
+// providing 10x+ performance improvement over SQL-based queries during backtesting.
+type InMemoryIndexedDataSource struct {
+	underlying DataSource
+
+	// Preloaded data indexed by symbol, then by bar index
+	// data[symbol][barIndex] = MarketData
+	data map[string][]types.MarketData
+
+	// Time index maps timestamps to bar indices for each symbol
+	// timeIndex[symbol][timestamp] = barIndex
+	timeIndex map[string]map[int64]int
+
+	// All data combined in chronological order for ReadAll iteration
+	allData []types.MarketData
+
+	// Current bar index for each symbol
+	currentBarIndex map[string]int
+
+	// Global bar index (for single-symbol or multi-symbol iteration)
+	globalBarIndex int
+
+	// Preload state
+	preloaded bool
+
+	// Mutex for thread-safe operations
+	mu sync.RWMutex
+}
+
+// NewInMemoryIndexedDataSource creates a new InMemoryIndexedDataSource wrapping the given DataSource.
+func NewInMemoryIndexedDataSource(underlying DataSource) *InMemoryIndexedDataSource {
+	return &InMemoryIndexedDataSource{
+		underlying:      underlying,
+		data:            make(map[string][]types.MarketData),
+		timeIndex:       make(map[string]map[int64]int),
+		allData:         nil,
+		currentBarIndex: make(map[string]int),
+		globalBarIndex:  0,
+		preloaded:       false,
+		mu:              sync.RWMutex{},
+	}
+}
+
+// Preload loads all data into memory for fast indexed access.
+func (ds *InMemoryIndexedDataSource) Preload(start optional.Option[time.Time], end optional.Option[time.Time]) error {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+
+	// Clear existing data
+	ds.data = make(map[string][]types.MarketData)
+	ds.timeIndex = make(map[string]map[int64]int)
+	ds.currentBarIndex = make(map[string]int)
+	ds.globalBarIndex = 0
+
+	// Load all data from underlying source
+	var allData []types.MarketData
+	for marketData, err := range ds.underlying.ReadAll(start, end) {
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeDataNotFound, "failed to preload data", err)
+		}
+		allData = append(allData, marketData)
+	}
+
+	// Sort by time to ensure chronological order
+	sort.Slice(allData, func(i, j int) bool {
+		return allData[i].Time.Before(allData[j].Time)
+	})
+
+	ds.allData = allData
+
+	// Index data by symbol
+	for _, md := range allData {
+		symbol := md.Symbol
+
+		// Initialize symbol maps if needed
+		if _, ok := ds.data[symbol]; !ok {
+			ds.data[symbol] = make([]types.MarketData, 0)
+			ds.timeIndex[symbol] = make(map[int64]int)
+			ds.currentBarIndex[symbol] = 0
+		}
+
+		// Add to symbol's data array
+		barIndex := len(ds.data[symbol])
+		ds.data[symbol] = append(ds.data[symbol], md)
+
+		// Create time index for backward compatibility
+		ds.timeIndex[symbol][md.Time.UnixNano()] = barIndex
+	}
+
+	ds.preloaded = true
+	return nil
+}
+
+// IsPreloaded returns true if data has been preloaded into memory.
+func (ds *InMemoryIndexedDataSource) IsPreloaded() bool {
+	ds.mu.RLock()
+	defer ds.mu.RUnlock()
+	return ds.preloaded
+}
+
+// SetCurrentBarIndex sets the current bar index for subsequent queries.
+func (ds *InMemoryIndexedDataSource) SetCurrentBarIndex(index int) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	ds.globalBarIndex = index
+
+	// Update per-symbol indices based on global index
+	// This assumes single-symbol iteration; for multi-symbol, use SetCurrentBarIndexForSymbol
+	for symbol := range ds.data {
+		if index < len(ds.data[symbol]) {
+			ds.currentBarIndex[symbol] = index
+		}
+	}
+}
+
+// SetCurrentBarIndexForSymbol sets the current bar index for a specific symbol.
+func (ds *InMemoryIndexedDataSource) SetCurrentBarIndexForSymbol(symbol string, index int) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	ds.currentBarIndex[symbol] = index
+}
+
+// GetCurrentBarIndex returns the current global bar index.
+func (ds *InMemoryIndexedDataSource) GetCurrentBarIndex() int {
+	ds.mu.RLock()
+	defer ds.mu.RUnlock()
+	return ds.globalBarIndex
+}
+
+// GetPreviousNBars returns the previous N bars ending at the current bar index.
+// This is an O(1) operation using array slicing.
+func (ds *InMemoryIndexedDataSource) GetPreviousNBars(symbol string, count int) ([]types.MarketData, error) {
+	ds.mu.RLock()
+	defer ds.mu.RUnlock()
+
+	if !ds.preloaded {
+		return nil, errors.New(errors.ErrCodeDataNotFound, "data not preloaded, call Preload() first")
+	}
+
+	symbolData, ok := ds.data[symbol]
+	if !ok {
+		return nil, errors.Newf(errors.ErrCodeDataNotFound, "no data found for symbol: %s", symbol)
+	}
+
+	currentIdx, ok := ds.currentBarIndex[symbol]
+	if !ok {
+		return nil, errors.Newf(errors.ErrCodeDataNotFound, "current bar index not set for symbol: %s", symbol)
+	}
+
+	// Calculate the start index for the slice
+	// We want `count` bars ending at currentIdx (inclusive)
+	startIdx := currentIdx - count + 1
+	if startIdx < 0 {
+		startIdx = 0
+	}
+
+	// Slice end is currentIdx + 1 (exclusive)
+	endIdx := currentIdx + 1
+	if endIdx > len(symbolData) {
+		endIdx = len(symbolData)
+	}
+
+	actualCount := endIdx - startIdx
+	if actualCount < count {
+		return nil, errors.NewInsufficientDataErrorf(count, actualCount, symbol,
+			"insufficient data points for symbol %s: requested %d, got %d", symbol, count, actualCount)
+	}
+
+	// Return a copy to prevent modification of underlying data
+	result := make([]types.MarketData, actualCount)
+	copy(result, symbolData[startIdx:endIdx])
+
+	return result, nil
+}
+
+// GetBarAtIndex returns the market data at a specific bar index.
+func (ds *InMemoryIndexedDataSource) GetBarAtIndex(symbol string, index int) (types.MarketData, error) {
+	ds.mu.RLock()
+	defer ds.mu.RUnlock()
+
+	if !ds.preloaded {
+		return types.MarketData{}, errors.New(errors.ErrCodeDataNotFound, "data not preloaded, call Preload() first")
+	}
+
+	symbolData, ok := ds.data[symbol]
+	if !ok {
+		return types.MarketData{}, errors.Newf(errors.ErrCodeDataNotFound, "no data found for symbol: %s", symbol)
+	}
+
+	if index < 0 || index >= len(symbolData) {
+		return types.MarketData{}, errors.Newf(errors.ErrCodeDataNotFound,
+			"bar index %d out of range [0, %d) for symbol %s", index, len(symbolData), symbol)
+	}
+
+	return symbolData[index], nil
+}
+
+// GetTotalBars returns the total number of bars loaded for a symbol.
+func (ds *InMemoryIndexedDataSource) GetTotalBars(symbol string) int {
+	ds.mu.RLock()
+	defer ds.mu.RUnlock()
+
+	if symbolData, ok := ds.data[symbol]; ok {
+		return len(symbolData)
+	}
+	return 0
+}
+
+// ========================================
+// DataSource interface implementation
+// ========================================
+
+// Initialize implements DataSource.
+func (ds *InMemoryIndexedDataSource) Initialize(path string) error {
+	return ds.underlying.Initialize(path)
+}
+
+// ReadAll implements DataSource.
+// When preloaded, iterates over in-memory data with automatic index tracking.
+func (ds *InMemoryIndexedDataSource) ReadAll(start optional.Option[time.Time], end optional.Option[time.Time]) func(yield func(types.MarketData, error) bool) {
+	return func(yield func(types.MarketData, error) bool) {
+		ds.mu.RLock()
+		preloaded := ds.preloaded
+		allData := ds.allData
+		ds.mu.RUnlock()
+
+		if preloaded && allData != nil {
+			// Use preloaded data with index tracking
+			symbolIndices := make(map[string]int)
+
+			for i, md := range allData {
+				// Update the current bar index for this symbol
+				ds.mu.Lock()
+				ds.globalBarIndex = i
+				symbolIndices[md.Symbol]++
+				ds.currentBarIndex[md.Symbol] = symbolIndices[md.Symbol] - 1
+				ds.mu.Unlock()
+
+				if !yield(md, nil) {
+					return
+				}
+			}
+		} else {
+			// Fall back to underlying datasource
+			for md, err := range ds.underlying.ReadAll(start, end) {
+				if !yield(md, err) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// GetRange implements DataSource.
+func (ds *InMemoryIndexedDataSource) GetRange(start time.Time, end time.Time, interval optional.Option[Interval]) ([]types.MarketData, error) {
+	ds.mu.RLock()
+	preloaded := ds.preloaded
+	ds.mu.RUnlock()
+
+	if preloaded {
+		// Use in-memory data
+		ds.mu.RLock()
+		defer ds.mu.RUnlock()
+
+		var result []types.MarketData
+		for _, md := range ds.allData {
+			if !md.Time.Before(start) && !md.Time.After(end) {
+				result = append(result, md)
+			}
+		}
+		return result, nil
+	}
+
+	return ds.underlying.GetRange(start, end, interval)
+}
+
+// GetPreviousNumberOfDataPoints implements DataSource.
+// When preloaded, uses O(1) indexed access instead of SQL queries.
+func (ds *InMemoryIndexedDataSource) GetPreviousNumberOfDataPoints(end time.Time, symbol string, count int) ([]types.MarketData, error) {
+	ds.mu.RLock()
+	preloaded := ds.preloaded
+	ds.mu.RUnlock()
+
+	if preloaded {
+		ds.mu.RLock()
+		defer ds.mu.RUnlock()
+
+		symbolData, ok := ds.data[symbol]
+		if !ok {
+			return nil, errors.Newf(errors.ErrCodeDataNotFound, "no data found for symbol: %s", symbol)
+		}
+
+		// Find the bar index for this timestamp using time index
+		timeIdx, ok := ds.timeIndex[symbol]
+		if !ok {
+			return nil, errors.Newf(errors.ErrCodeDataNotFound, "no time index for symbol: %s", symbol)
+		}
+
+		endIdx, ok := timeIdx[end.UnixNano()]
+		if !ok {
+			// Fallback: linear search for closest time <= end
+			endIdx = -1
+			for i, md := range symbolData {
+				if !md.Time.After(end) {
+					endIdx = i
+				} else {
+					break
+				}
+			}
+			if endIdx < 0 {
+				return nil, errors.Newf(errors.ErrCodeDataNotFound, "no data found before time %v for symbol %s", end, symbol)
+			}
+		}
+
+		// Calculate start index
+		startIdx := endIdx - count + 1
+		if startIdx < 0 {
+			startIdx = 0
+		}
+
+		actualCount := endIdx - startIdx + 1
+		if actualCount < count {
+			return nil, errors.NewInsufficientDataErrorf(count, actualCount, symbol,
+				"insufficient data points for symbol %s: requested %d, got %d", symbol, count, actualCount)
+		}
+
+		// Return a copy
+		result := make([]types.MarketData, count)
+		copy(result, symbolData[startIdx:endIdx+1])
+
+		return result, nil
+	}
+
+	return ds.underlying.GetPreviousNumberOfDataPoints(end, symbol, count)
+}
+
+// GetMarketData implements DataSource.
+func (ds *InMemoryIndexedDataSource) GetMarketData(symbol string, timestamp time.Time) (types.MarketData, error) {
+	ds.mu.RLock()
+	preloaded := ds.preloaded
+	ds.mu.RUnlock()
+
+	if preloaded {
+		ds.mu.RLock()
+		defer ds.mu.RUnlock()
+
+		timeIdx, ok := ds.timeIndex[symbol]
+		if !ok {
+			return types.MarketData{}, errors.Newf(errors.ErrCodeDataNotFound, "no data found for symbol: %s", symbol)
+		}
+
+		idx, ok := timeIdx[timestamp.UnixNano()]
+		if !ok {
+			return types.MarketData{}, errors.Newf(errors.ErrCodeDataNotFound, "no data found for symbol %s at time %v", symbol, timestamp)
+		}
+
+		return ds.data[symbol][idx], nil
+	}
+
+	return ds.underlying.GetMarketData(symbol, timestamp)
+}
+
+// ReadLastData implements DataSource.
+func (ds *InMemoryIndexedDataSource) ReadLastData(symbol string) (types.MarketData, error) {
+	ds.mu.RLock()
+	preloaded := ds.preloaded
+	ds.mu.RUnlock()
+
+	if preloaded {
+		ds.mu.RLock()
+		defer ds.mu.RUnlock()
+
+		symbolData, ok := ds.data[symbol]
+		if !ok || len(symbolData) == 0 {
+			return types.MarketData{}, errors.Newf(errors.ErrCodeDataNotFound, "no data found for symbol: %s", symbol)
+		}
+
+		return symbolData[len(symbolData)-1], nil
+	}
+
+	return ds.underlying.ReadLastData(symbol)
+}
+
+// ExecuteSQL implements DataSource.
+// SQL queries are passed to underlying datasource (cannot be served from memory).
+func (ds *InMemoryIndexedDataSource) ExecuteSQL(query string, params ...interface{}) ([]SQLResult, error) {
+	return ds.underlying.ExecuteSQL(query, params...)
+}
+
+// Count implements DataSource.
+func (ds *InMemoryIndexedDataSource) Count(start optional.Option[time.Time], end optional.Option[time.Time]) (int, error) {
+	ds.mu.RLock()
+	preloaded := ds.preloaded
+	ds.mu.RUnlock()
+
+	if preloaded {
+		ds.mu.RLock()
+		defer ds.mu.RUnlock()
+
+		if start.IsNone() && end.IsNone() {
+			return len(ds.allData), nil
+		}
+
+		count := 0
+		for _, md := range ds.allData {
+			if start.IsSome() && md.Time.Before(start.Unwrap()) {
+				continue
+			}
+			if end.IsSome() && md.Time.After(end.Unwrap()) {
+				continue
+			}
+			count++
+		}
+		return count, nil
+	}
+
+	return ds.underlying.Count(start, end)
+}
+
+// Close implements DataSource.
+func (ds *InMemoryIndexedDataSource) Close() error {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+
+	// Clear preloaded data
+	ds.data = nil
+	ds.timeIndex = nil
+	ds.allData = nil
+	ds.currentBarIndex = nil
+	ds.preloaded = false
+
+	return ds.underlying.Close()
+}
+
+// GetAllSymbols implements DataSource.
+func (ds *InMemoryIndexedDataSource) GetAllSymbols() ([]string, error) {
+	ds.mu.RLock()
+	preloaded := ds.preloaded
+	ds.mu.RUnlock()
+
+	if preloaded {
+		ds.mu.RLock()
+		defer ds.mu.RUnlock()
+
+		symbols := make([]string, 0, len(ds.data))
+		for symbol := range ds.data {
+			symbols = append(symbols, symbol)
+		}
+		return symbols, nil
+	}
+
+	return ds.underlying.GetAllSymbols()
+}

--- a/internal/backtest/engine/engine_v1/datasource/in_memory_indexed_datasource_test.go
+++ b/internal/backtest/engine/engine_v1/datasource/in_memory_indexed_datasource_test.go
@@ -1,0 +1,282 @@
+package datasource
+
+import (
+	"testing"
+	"time"
+
+	"github.com/moznion/go-optional"
+	"github.com/rxtech-lab/argo-trading/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockDataSource is a mock implementation of DataSource for testing
+type MockDataSource struct {
+	mock.Mock
+	data []types.MarketData
+}
+
+func (m *MockDataSource) Initialize(path string) error {
+	args := m.Called(path)
+	return args.Error(0)
+}
+
+func (m *MockDataSource) ReadAll(start optional.Option[time.Time], end optional.Option[time.Time]) func(yield func(types.MarketData, error) bool) {
+	return func(yield func(types.MarketData, error) bool) {
+		for _, d := range m.data {
+			if start.IsSome() && d.Time.Before(start.Unwrap()) {
+				continue
+			}
+			if end.IsSome() && d.Time.After(end.Unwrap()) {
+				continue
+			}
+			if !yield(d, nil) {
+				return
+			}
+		}
+	}
+}
+
+func (m *MockDataSource) GetRange(start time.Time, end time.Time, interval optional.Option[Interval]) ([]types.MarketData, error) {
+	args := m.Called(start, end, interval)
+	return args.Get(0).([]types.MarketData), args.Error(1)
+}
+
+func (m *MockDataSource) GetPreviousNumberOfDataPoints(end time.Time, symbol string, count int) ([]types.MarketData, error) {
+	args := m.Called(end, symbol, count)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]types.MarketData), args.Error(1)
+}
+
+func (m *MockDataSource) GetMarketData(symbol string, timestamp time.Time) (types.MarketData, error) {
+	args := m.Called(symbol, timestamp)
+	return args.Get(0).(types.MarketData), args.Error(1)
+}
+
+func (m *MockDataSource) ReadLastData(symbol string) (types.MarketData, error) {
+	args := m.Called(symbol)
+	return args.Get(0).(types.MarketData), args.Error(1)
+}
+
+func (m *MockDataSource) ExecuteSQL(query string, params ...interface{}) ([]SQLResult, error) {
+	args := m.Called(query, params)
+	return args.Get(0).([]SQLResult), args.Error(1)
+}
+
+func (m *MockDataSource) Count(start optional.Option[time.Time], end optional.Option[time.Time]) (int, error) {
+	return len(m.data), nil
+}
+
+func (m *MockDataSource) Close() error {
+	return nil
+}
+
+func (m *MockDataSource) GetAllSymbols() ([]string, error) {
+	symbolMap := make(map[string]bool)
+	for _, d := range m.data {
+		symbolMap[d.Symbol] = true
+	}
+	symbols := make([]string, 0, len(symbolMap))
+	for s := range symbolMap {
+		symbols = append(symbols, s)
+	}
+	return symbols, nil
+}
+
+// Helper to generate test data
+func generateTestData(symbol string, count int, startTime time.Time) []types.MarketData {
+	data := make([]types.MarketData, count)
+	for i := 0; i < count; i++ {
+		data[i] = types.MarketData{
+			Symbol: symbol,
+			Time:   startTime.Add(time.Duration(i) * time.Minute),
+			Open:   100.0 + float64(i),
+			High:   101.0 + float64(i),
+			Low:    99.0 + float64(i),
+			Close:  100.5 + float64(i),
+			Volume: 1000.0,
+		}
+	}
+	return data
+}
+
+func TestInMemoryIndexedDataSource_Preload(t *testing.T) {
+	startTime := time.Date(2024, 1, 1, 9, 30, 0, 0, time.UTC)
+	testData := generateTestData("TEST", 100, startTime)
+
+	mockDS := &MockDataSource{data: testData}
+	indexedDS := NewInMemoryIndexedDataSource(mockDS)
+
+	assert.False(t, indexedDS.IsPreloaded())
+
+	err := indexedDS.Preload(optional.None[time.Time](), optional.None[time.Time]())
+	assert.NoError(t, err)
+	assert.True(t, indexedDS.IsPreloaded())
+
+	// Verify data count
+	assert.Equal(t, 100, indexedDS.GetTotalBars("TEST"))
+}
+
+func TestInMemoryIndexedDataSource_GetPreviousNBars(t *testing.T) {
+	startTime := time.Date(2024, 1, 1, 9, 30, 0, 0, time.UTC)
+	testData := generateTestData("TEST", 100, startTime)
+
+	mockDS := &MockDataSource{data: testData}
+	indexedDS := NewInMemoryIndexedDataSource(mockDS)
+
+	err := indexedDS.Preload(optional.None[time.Time](), optional.None[time.Time]())
+	assert.NoError(t, err)
+
+	// Set current bar index to 50
+	indexedDS.SetCurrentBarIndex(50)
+
+	// Get previous 10 bars
+	bars, err := indexedDS.GetPreviousNBars("TEST", 10)
+	assert.NoError(t, err)
+	assert.Len(t, bars, 10)
+
+	// Verify bars are in chronological order (oldest to newest)
+	for i := 1; i < len(bars); i++ {
+		assert.True(t, bars[i].Time.After(bars[i-1].Time))
+	}
+
+	// The last bar should be at index 50
+	assert.Equal(t, testData[50].Time, bars[len(bars)-1].Time)
+}
+
+func TestInMemoryIndexedDataSource_GetPreviousNBars_InsufficientData(t *testing.T) {
+	startTime := time.Date(2024, 1, 1, 9, 30, 0, 0, time.UTC)
+	testData := generateTestData("TEST", 100, startTime)
+
+	mockDS := &MockDataSource{data: testData}
+	indexedDS := NewInMemoryIndexedDataSource(mockDS)
+
+	err := indexedDS.Preload(optional.None[time.Time](), optional.None[time.Time]())
+	assert.NoError(t, err)
+
+	// Set current bar index to 5
+	indexedDS.SetCurrentBarIndex(5)
+
+	// Request more bars than available
+	_, err = indexedDS.GetPreviousNBars("TEST", 20)
+	assert.Error(t, err)
+}
+
+func TestInMemoryIndexedDataSource_GetBarAtIndex(t *testing.T) {
+	startTime := time.Date(2024, 1, 1, 9, 30, 0, 0, time.UTC)
+	testData := generateTestData("TEST", 100, startTime)
+
+	mockDS := &MockDataSource{data: testData}
+	indexedDS := NewInMemoryIndexedDataSource(mockDS)
+
+	err := indexedDS.Preload(optional.None[time.Time](), optional.None[time.Time]())
+	assert.NoError(t, err)
+
+	// Get bar at index 25
+	bar, err := indexedDS.GetBarAtIndex("TEST", 25)
+	assert.NoError(t, err)
+	assert.Equal(t, testData[25].Time, bar.Time)
+	assert.Equal(t, testData[25].Close, bar.Close)
+}
+
+func TestInMemoryIndexedDataSource_GetBarAtIndex_OutOfRange(t *testing.T) {
+	startTime := time.Date(2024, 1, 1, 9, 30, 0, 0, time.UTC)
+	testData := generateTestData("TEST", 100, startTime)
+
+	mockDS := &MockDataSource{data: testData}
+	indexedDS := NewInMemoryIndexedDataSource(mockDS)
+
+	err := indexedDS.Preload(optional.None[time.Time](), optional.None[time.Time]())
+	assert.NoError(t, err)
+
+	// Try to get bar at invalid index
+	_, err = indexedDS.GetBarAtIndex("TEST", 150)
+	assert.Error(t, err)
+}
+
+func TestInMemoryIndexedDataSource_GetPreviousNumberOfDataPoints(t *testing.T) {
+	startTime := time.Date(2024, 1, 1, 9, 30, 0, 0, time.UTC)
+	testData := generateTestData("TEST", 100, startTime)
+
+	mockDS := &MockDataSource{data: testData}
+	indexedDS := NewInMemoryIndexedDataSource(mockDS)
+
+	err := indexedDS.Preload(optional.None[time.Time](), optional.None[time.Time]())
+	assert.NoError(t, err)
+
+	// Get previous 10 data points ending at bar 50's time
+	endTime := testData[50].Time
+	bars, err := indexedDS.GetPreviousNumberOfDataPoints(endTime, "TEST", 10)
+	assert.NoError(t, err)
+	assert.Len(t, bars, 10)
+
+	// The last bar should match the end time
+	assert.Equal(t, endTime, bars[len(bars)-1].Time)
+}
+
+func TestInMemoryIndexedDataSource_ReadAll_WithPreload(t *testing.T) {
+	startTime := time.Date(2024, 1, 1, 9, 30, 0, 0, time.UTC)
+	testData := generateTestData("TEST", 100, startTime)
+
+	mockDS := &MockDataSource{data: testData}
+	indexedDS := NewInMemoryIndexedDataSource(mockDS)
+
+	err := indexedDS.Preload(optional.None[time.Time](), optional.None[time.Time]())
+	assert.NoError(t, err)
+
+	// Iterate through all data
+	count := 0
+	for md, err := range indexedDS.ReadAll(optional.None[time.Time](), optional.None[time.Time]()) {
+		assert.NoError(t, err)
+		assert.Equal(t, testData[count].Time, md.Time)
+		count++
+	}
+	assert.Equal(t, 100, count)
+}
+
+func TestInMemoryIndexedDataSource_GetAllSymbols(t *testing.T) {
+	startTime := time.Date(2024, 1, 1, 9, 30, 0, 0, time.UTC)
+	testData := generateTestData("TEST", 50, startTime)
+	testData = append(testData, generateTestData("AAPL", 50, startTime)...)
+
+	mockDS := &MockDataSource{data: testData}
+	indexedDS := NewInMemoryIndexedDataSource(mockDS)
+
+	err := indexedDS.Preload(optional.None[time.Time](), optional.None[time.Time]())
+	assert.NoError(t, err)
+
+	symbols, err := indexedDS.GetAllSymbols()
+	assert.NoError(t, err)
+	assert.Len(t, symbols, 2)
+}
+
+func TestInMemoryIndexedDataSource_NotPreloaded(t *testing.T) {
+	startTime := time.Date(2024, 1, 1, 9, 30, 0, 0, time.UTC)
+	testData := generateTestData("TEST", 100, startTime)
+
+	mockDS := &MockDataSource{data: testData}
+	indexedDS := NewInMemoryIndexedDataSource(mockDS)
+
+	// Without preloading, GetPreviousNBars should fail
+	_, err := indexedDS.GetPreviousNBars("TEST", 10)
+	assert.Error(t, err)
+}
+
+func TestInMemoryIndexedDataSource_MultipleSymbols(t *testing.T) {
+	startTime := time.Date(2024, 1, 1, 9, 30, 0, 0, time.UTC)
+	aaplData := generateTestData("AAPL", 50, startTime)
+	googData := generateTestData("GOOG", 50, startTime)
+	allData := append(aaplData, googData...)
+
+	mockDS := &MockDataSource{data: allData}
+	indexedDS := NewInMemoryIndexedDataSource(mockDS)
+
+	err := indexedDS.Preload(optional.None[time.Time](), optional.None[time.Time]())
+	assert.NoError(t, err)
+
+	assert.Equal(t, 50, indexedDS.GetTotalBars("AAPL"))
+	assert.Equal(t, 50, indexedDS.GetTotalBars("GOOG"))
+	assert.Equal(t, 0, indexedDS.GetTotalBars("MSFT")) // Non-existent symbol
+}

--- a/internal/backtest/engine/engine_v1/datasource/indexed_datasource.go
+++ b/internal/backtest/engine/engine_v1/datasource/indexed_datasource.go
@@ -1,0 +1,40 @@
+package datasource
+
+import (
+	"time"
+
+	"github.com/moznion/go-optional"
+	"github.com/rxtech-lab/argo-trading/internal/types"
+)
+
+// IndexedDataSource extends DataSource with bar-index-based access methods.
+// This interface enables O(1) lookups during backtesting by using array indices
+// instead of time-based SQL queries, providing significant performance improvements.
+type IndexedDataSource interface {
+	DataSource
+
+	// SetCurrentBarIndex sets the current bar index for subsequent queries.
+	// This must be called before each bar is processed during backtesting.
+	SetCurrentBarIndex(index int)
+
+	// GetCurrentBarIndex returns the current bar index.
+	GetCurrentBarIndex() int
+
+	// GetPreviousNBars returns the previous N bars ending at the current bar index.
+	// This is an O(1) operation using array slicing instead of SQL queries.
+	// Returns data in chronological order (oldest to newest).
+	GetPreviousNBars(symbol string, count int) ([]types.MarketData, error)
+
+	// GetBarAtIndex returns the market data at a specific bar index.
+	GetBarAtIndex(symbol string, index int) (types.MarketData, error)
+
+	// GetTotalBars returns the total number of bars loaded for a symbol.
+	GetTotalBars(symbol string) int
+
+	// Preload loads all data into memory for fast indexed access.
+	// This should be called once before backtesting begins.
+	Preload(start optional.Option[time.Time], end optional.Option[time.Time]) error
+
+	// IsPreloaded returns true if data has been preloaded into memory.
+	IsPreloaded() bool
+}

--- a/mocks/data_generator.go
+++ b/mocks/data_generator.go
@@ -1,0 +1,163 @@
+package mocks
+
+import (
+	"math"
+	"math/rand"
+	"time"
+
+	"github.com/rxtech-lab/argo-trading/internal/types"
+)
+
+// DataGenerator generates realistic market data for testing and benchmarking.
+type DataGenerator struct {
+	rng *rand.Rand
+}
+
+// NewDataGenerator creates a new DataGenerator with the given seed.
+// Use a fixed seed for reproducible results in tests.
+func NewDataGenerator(seed int64) *DataGenerator {
+	return &DataGenerator{
+		rng: rand.New(rand.NewSource(seed)),
+	}
+}
+
+// GeneratorConfig configures how market data is generated.
+type GeneratorConfig struct {
+	// Symbol is the trading symbol (e.g., "AAPL", "SPY")
+	Symbol string
+	// StartTime is the beginning of the data series
+	StartTime time.Time
+	// Interval is the duration between each bar
+	Interval time.Duration
+	// Count is the number of data points to generate
+	Count int
+	// InitialPrice is the starting price
+	InitialPrice float64
+	// Volatility controls price movement (0.01 = 1% typical daily volatility)
+	Volatility float64
+	// Trend is the drift factor (-0.01 to 0.01 for bearish to bullish)
+	Trend float64
+	// VolumeBase is the average volume per bar
+	VolumeBase float64
+	// VolumeVariance is the variance in volume (0.0 to 1.0)
+	VolumeVariance float64
+}
+
+// DefaultConfig returns a sensible default configuration.
+func DefaultConfig() GeneratorConfig {
+	return GeneratorConfig{
+		Symbol:         "TEST",
+		StartTime:      time.Date(2024, 1, 1, 9, 30, 0, 0, time.UTC),
+		Interval:       time.Minute,
+		Count:          10000,
+		InitialPrice:   100.0,
+		Volatility:     0.002, // 0.2% per bar
+		Trend:          0.0,   // neutral
+		VolumeBase:     10000,
+		VolumeVariance: 0.3,
+	}
+}
+
+// Generate creates a slice of MarketData based on the configuration.
+// The generated data follows a geometric Brownian motion model for realistic price movements.
+func (g *DataGenerator) Generate(config GeneratorConfig) []types.MarketData {
+	data := make([]types.MarketData, config.Count)
+	currentPrice := config.InitialPrice
+	currentTime := config.StartTime
+
+	for i := 0; i < config.Count; i++ {
+		// Generate OHLCV using geometric Brownian motion
+		open := currentPrice
+
+		// Generate intra-bar price movements
+		// Using Box-Muller transform for normal distribution
+		u1 := g.rng.Float64()
+		u2 := g.rng.Float64()
+		z := math.Sqrt(-2*math.Log(u1)) * math.Cos(2*math.Pi*u2)
+
+		// Price change with trend and volatility
+		priceChange := config.Volatility * z
+		drift := config.Trend / float64(config.Count) // Distribute trend across bars
+
+		close := open * (1 + priceChange + drift)
+		if close <= 0 {
+			close = open * 0.99 // Prevent negative prices
+		}
+
+		// High and low are within the open-close range plus some extension
+		highExtension := math.Abs(g.rng.Float64() * config.Volatility * open * 0.5)
+		lowExtension := math.Abs(g.rng.Float64() * config.Volatility * open * 0.5)
+
+		high := math.Max(open, close) + highExtension
+		low := math.Min(open, close) - lowExtension
+		if low <= 0 {
+			low = math.Min(open, close) * 0.99
+		}
+
+		// Volume with variance
+		volumeVariation := 1.0 + (g.rng.Float64()*2-1)*config.VolumeVariance
+		volume := config.VolumeBase * volumeVariation
+		if volume < 0 {
+			volume = config.VolumeBase * 0.1
+		}
+
+		data[i] = types.MarketData{
+			Id:     "",
+			Symbol: config.Symbol,
+			Time:   currentTime,
+			Open:   roundToDecimals(open, 4),
+			High:   roundToDecimals(high, 4),
+			Low:    roundToDecimals(low, 4),
+			Close:  roundToDecimals(close, 4),
+			Volume: roundToDecimals(volume, 2),
+		}
+
+		// Update for next iteration
+		currentPrice = close
+		currentTime = currentTime.Add(config.Interval)
+	}
+
+	return data
+}
+
+// GenerateMultiSymbol generates data for multiple symbols.
+func (g *DataGenerator) GenerateMultiSymbol(symbols []string, baseConfig GeneratorConfig) []types.MarketData {
+	var allData []types.MarketData
+
+	for _, symbol := range symbols {
+		config := baseConfig
+		config.Symbol = symbol
+		// Vary initial price and volatility slightly per symbol
+		config.InitialPrice = baseConfig.InitialPrice * (0.8 + g.rng.Float64()*0.4)
+		config.Volatility = baseConfig.Volatility * (0.8 + g.rng.Float64()*0.4)
+
+		symbolData := g.Generate(config)
+		allData = append(allData, symbolData...)
+	}
+
+	return allData
+}
+
+// Generate10K is a convenience function to generate 10,000 data points
+// with default settings for benchmarking.
+func Generate10K(symbol string) []types.MarketData {
+	gen := NewDataGenerator(42) // Fixed seed for reproducibility
+	config := DefaultConfig()
+	config.Symbol = symbol
+	config.Count = 10000
+	return gen.Generate(config)
+}
+
+// Generate10KMultiSymbol generates 10,000 data points for each symbol.
+func Generate10KMultiSymbol(symbols []string) []types.MarketData {
+	gen := NewDataGenerator(42)
+	config := DefaultConfig()
+	config.Count = 10000
+	return gen.GenerateMultiSymbol(symbols, config)
+}
+
+// roundToDecimals rounds a float64 to the specified number of decimal places.
+func roundToDecimals(val float64, decimals int) float64 {
+	pow := math.Pow(10, float64(decimals))
+	return math.Round(val*pow) / pow
+}

--- a/mocks/data_generator_test.go
+++ b/mocks/data_generator_test.go
@@ -1,0 +1,166 @@
+package mocks
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDataGenerator_Generate(t *testing.T) {
+	gen := NewDataGenerator(42) // Fixed seed for reproducibility
+	config := DefaultConfig()
+	config.Count = 100
+
+	data := gen.Generate(config)
+
+	if len(data) != 100 {
+		t.Errorf("expected 100 data points, got %d", len(data))
+	}
+
+	// Verify data is in chronological order
+	for i := 1; i < len(data); i++ {
+		if !data[i].Time.After(data[i-1].Time) {
+			t.Errorf("data not in chronological order at index %d", i)
+		}
+	}
+
+	// Verify symbol is set correctly
+	for i, d := range data {
+		if d.Symbol != config.Symbol {
+			t.Errorf("expected symbol %s at index %d, got %s", config.Symbol, i, d.Symbol)
+		}
+	}
+
+	// Verify OHLC values are positive
+	for i, d := range data {
+		if d.Open <= 0 || d.High <= 0 || d.Low <= 0 || d.Close <= 0 {
+			t.Errorf("invalid OHLC values at index %d: O=%f H=%f L=%f C=%f",
+				i, d.Open, d.High, d.Low, d.Close)
+		}
+	}
+
+	// Verify High >= Low
+	for i, d := range data {
+		if d.High < d.Low {
+			t.Errorf("High < Low at index %d: H=%f L=%f", i, d.High, d.Low)
+		}
+	}
+
+	// Verify time intervals
+	expectedInterval := config.Interval
+	for i := 1; i < len(data); i++ {
+		actualInterval := data[i].Time.Sub(data[i-1].Time)
+		if actualInterval != expectedInterval {
+			t.Errorf("unexpected interval at index %d: expected %v, got %v",
+				i, expectedInterval, actualInterval)
+		}
+	}
+}
+
+func TestDataGenerator_Reproducibility(t *testing.T) {
+	// Same seed should produce same results
+	gen1 := NewDataGenerator(42)
+	gen2 := NewDataGenerator(42)
+
+	config := DefaultConfig()
+	config.Count = 10
+
+	data1 := gen1.Generate(config)
+	data2 := gen2.Generate(config)
+
+	for i := range data1 {
+		if data1[i].Close != data2[i].Close {
+			t.Errorf("data not reproducible at index %d: got %f and %f",
+				i, data1[i].Close, data2[i].Close)
+		}
+	}
+}
+
+func TestDataGenerator_Different_Seeds(t *testing.T) {
+	gen1 := NewDataGenerator(42)
+	gen2 := NewDataGenerator(123)
+
+	config := DefaultConfig()
+	config.Count = 10
+
+	data1 := gen1.Generate(config)
+	data2 := gen2.Generate(config)
+
+	// Different seeds should produce different results
+	sameCount := 0
+	for i := range data1 {
+		if data1[i].Close == data2[i].Close {
+			sameCount++
+		}
+	}
+
+	if sameCount == len(data1) {
+		t.Error("different seeds produced identical data")
+	}
+}
+
+func TestGenerate10K(t *testing.T) {
+	data := Generate10K("TEST")
+
+	if len(data) != 10000 {
+		t.Errorf("expected 10000 data points, got %d", len(data))
+	}
+
+	// Verify first data point
+	if data[0].Symbol != "TEST" {
+		t.Errorf("expected symbol TEST, got %s", data[0].Symbol)
+	}
+
+	// Verify chronological order
+	for i := 1; i < 100; i++ { // Check first 100 for speed
+		if !data[i].Time.After(data[i-1].Time) {
+			t.Errorf("data not in chronological order at index %d", i)
+		}
+	}
+}
+
+func TestGenerateMultiSymbol(t *testing.T) {
+	symbols := []string{"AAPL", "GOOG", "MSFT"}
+	gen := NewDataGenerator(42)
+	config := DefaultConfig()
+	config.Count = 100
+
+	data := gen.GenerateMultiSymbol(symbols, config)
+
+	expectedTotal := len(symbols) * config.Count
+	if len(data) != expectedTotal {
+		t.Errorf("expected %d data points, got %d", expectedTotal, len(data))
+	}
+
+	// Verify each symbol has data
+	symbolCounts := make(map[string]int)
+	for _, d := range data {
+		symbolCounts[d.Symbol]++
+	}
+
+	for _, symbol := range symbols {
+		if symbolCounts[symbol] != config.Count {
+			t.Errorf("expected %d data points for %s, got %d",
+				config.Count, symbol, symbolCounts[symbol])
+		}
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	config := DefaultConfig()
+
+	if config.Count != 10000 {
+		t.Errorf("expected default count 10000, got %d", config.Count)
+	}
+
+	if config.Symbol != "TEST" {
+		t.Errorf("expected default symbol TEST, got %s", config.Symbol)
+	}
+
+	if config.Interval != time.Minute {
+		t.Errorf("expected default interval 1m, got %v", config.Interval)
+	}
+
+	if config.InitialPrice != 100.0 {
+		t.Errorf("expected default initial price 100.0, got %f", config.InitialPrice)
+	}
+}


### PR DESCRIPTION
This commit introduces major performance improvements to the backtesting
engine by implementing in-memory indexed data access instead of SQL queries.

Key changes:

1. Add InMemoryIndexedDataSource (datasource/in_memory_indexed_datasource.go):
   - Preloads all data into memory for fast indexed access
   - Uses O(1) array slicing instead of O(log n) SQL queries
   - Supports bar-index-based lookups via GetPreviousNBars()
   - Falls back to underlying datasource when not preloaded

2. Add IndexedDataSource interface (datasource/indexed_datasource.go):
   - Defines bar-index-based access methods
   - SetCurrentBarIndex/GetCurrentBarIndex for tracking position
   - GetPreviousNBars for O(1) historical data retrieval

3. Add DataGenerator for benchmarking (mocks/data_generator.go):
   - Generates realistic market data using geometric Brownian motion
   - Supports 10k+ data point generation for performance testing
   - Configurable volatility, trend, and time intervals

4. Update backtest engine (backtest_v1.go):
   - Replace CachedDataSource with InMemoryIndexedDataSource
   - Add preloading step after data initialization
   - Remove per-bar cache clearing (no longer needed)

5. DuckDB optimizations (duck_db_datasource.go):
   - Convert view to table for index support
   - Add composite index on (symbol, time)
   - Enable connection pooling
   - Add additional DuckDB performance settings

6. Add comprehensive benchmark tests:
   - Compare DuckDB vs InMemoryIndexed vs DirectBarIndexed
   - Test multiple indicator query patterns
   - Verify 10x+ performance improvement

Performance improvement: Direct bar-indexed access provides 10x+ faster
indicator calculations compared to SQL-based queries.