### PR TITLE
feat: add docs-publishing skill

### DIFF
--- a/.claude/skills/docs-publishing/SKILL.md
+++ b/.claude/skills/docs-publishing/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: docs-publishing
+description: Set up automated documentation publishing for any repository. Authors markdown docs with frontmatter, generates API/code docs per language, drops in a stdlib uploader script plus a GitHub Actions workflow that pushes docs to the autopilot docs service on every push to main, and provisions the upload token as a repo secret. Use when a user wants to publish, upload, or sync a repo's docs to the docs service / autopilot, set up a docs CI pipeline, or wire up DOCS_UPLOAD_TOKEN.
+---
+
+# Docs Publishing
+
+Set up a complete, token-authenticated documentation pipeline for **any** repository. On every push to `main` that touches `docs/`, a GitHub Actions job uploads the repo's markdown docs to the autopilot docs service (`https://autopilot.rxlab.app`).
+
+This skill is portable across languages (Go, TypeScript/JavaScript, Java, Python, …). It bundles two templates:
+
+- `templates/upload_docs.py` — the stdlib uploader (no pip dependencies).
+- `templates/upload-docs.yaml` — the GitHub Actions workflow.
+
+## Mental model
+
+```
+docs/**/*.md  ──parse frontmatter──▶  {docId: slug, content: body}
+      │                                        │
+      │  (per-language generators emit here)   ▼  POST in batches of 50
+      ▼                          Bearer DOCS_UPLOAD_TOKEN
+ handwritten + API + code docs ─────────────────▶ https://autopilot.rxlab.app
+                                  /api/v1/docs/repositories/{urlencoded repo}/documents
+```
+
+The contract is **frontmatter `slug`**: every markdown file that should be published declares a unique `slug`, which becomes its remote `docId`. Files without a `slug` are skipped; duplicate slugs are a hard error.
+
+## Steps
+
+### 1. Author docs under `docs/`
+
+All published docs live as markdown under `docs/` (nested folders are fine — the uploader walks recursively). Each file needs YAML frontmatter:
+
+```markdown
+---
+slug: indicators/rsi          # REQUIRED, unique. Becomes the remote docId.
+title: RSI (Relative Strength Index)
+description: Momentum oscillator — configuration, values, signals.
+---
+
+# RSI (Relative Strength Index)
+
+Body markdown here…
+```
+
+Rules enforced by the uploader:
+- **No `slug` → skipped** (logged to stderr).
+- **Duplicate `slug` → the run fails** (`exit 1`). Keep slugs unique across the whole tree.
+- `title` / `description` are conventional and used by index generators; only `slug` is required for upload.
+
+### 2. Produce each doc TYPE
+
+Emit everything into `docs/` so one uploader handles all of it. Add frontmatter (`slug`/`title`/`description`) to each generated/authored file — for generated output, post-process or template a header so the `slug` is present.
+
+- **Design / architecture docs** — handwritten markdown. *Always* include these (overview, data flow, key decisions). No tool; just write them under `docs/`.
+- **API docs (OpenAPI / Swagger)** — commit the spec under `docs/` (e.g. `docs/api/openapi.yaml`) and, if you want rendered prose, generate markdown from it (e.g. `widdershins openapi.yaml -o docs/api/reference.md`). Give the rendered file a `slug`.
+- **Code docs**, per language — generate into `docs/` and ensure each emitted page carries frontmatter:
+  - **Go** → [`gomarkdoc`](https://github.com/princjef/gomarkdoc): `gomarkdoc ./... --output docs/api/{{.Dir}}.md`
+  - **TypeScript / JavaScript** → [TypeDoc](https://typedoc.org) with the markdown plugin: `typedoc --plugin typedoc-plugin-markdown --out docs/api src/index.ts` (or JSDoc + `jsdoc-to-markdown`: `jsdoc2md src/**/*.js > docs/api/reference.md`)
+  - **Java** → Javadoc: `javadoc -d docs/api -sourcepath src/main/java <packages>` (HTML; for markdown use a doclet, or keep HTML and publish via Pages instead)
+
+> Tip: if a generator can't emit frontmatter, add a small post-process step (sed/python) to prepend a `slug` derived from the file path before the upload step runs.
+
+### 3. Drop in the uploader script
+
+Copy the bundled template into the repo:
+
+```bash
+mkdir -p scripts
+cp .claude/skills/docs-publishing/templates/upload_docs.py scripts/upload_docs.py
+chmod +x scripts/upload_docs.py
+```
+
+What it does (stdlib only — `urllib`, no pip installs):
+- Walks `--docs-dir` (default `docs`), parses frontmatter, keeps files with a `slug`.
+- Builds `{"documents": [{"docId": slug, "content": body}, …]}`.
+- POSTs in batches of 50 to `{endpoint}/api/v1/docs/repositories/{urlencoded repo-id}/documents` with header `Authorization: Bearer <token>`.
+- Config via env (CLI flags override): `DOCS_ENDPOINT` (default `https://autopilot.rxlab.app`), `DOCS_REPOSITORY_ID`, `DOCS_UPLOAD_TOKEN`. Supports `--dry-run`.
+
+### 4. Drop in the workflow
+
+```bash
+mkdir -p .github/workflows
+cp .claude/skills/docs-publishing/templates/upload-docs.yaml .github/workflows/upload-docs.yaml
+```
+
+Then edit one line — set `DOCS_REPOSITORY_ID` to your repo:
+
+```yaml
+              env:
+                  DOCS_ENDPOINT: https://autopilot.rxlab.app
+                  DOCS_REPOSITORY_ID: <OWNER>/<REPO>      # e.g. rxtech-lab/argo-trading
+                  DOCS_UPLOAD_TOKEN: ${{ secrets.DOCS_UPLOAD_TOKEN }}
+              run: python scripts/upload_docs.py
+```
+
+Triggers: push to `main` filtered to `paths: [docs/**, scripts/upload_docs.py, .github/workflows/upload-docs.yaml]`, plus manual `workflow_dispatch`. A `concurrency` group with `cancel-in-progress: false` prevents overlapping uploads from racing. If you also generate code/API docs in CI, add those generation steps **before** the "Upload docs" step in this same job.
+
+### 5. Provision the upload token as a repo secret
+
+Obtain a token from the github-pm docs service:
+
+```
+POST /api/v1/docs/repositories/[id]/upload-tokens
+```
+
+The token is prefixed `dput_` (per-upload) or `dpat_` (personal access). Then set it as a GitHub Actions secret with the `gh` CLI:
+
+```bash
+gh secret set DOCS_UPLOAD_TOKEN --body "<dput_ or dpat_ token>" --repo <OWNER>/<REPO>
+```
+
+(Run `gh auth login` first if needed. To verify it exists: `gh secret list --repo <OWNER>/<REPO>`.)
+
+### 6. Verify
+
+```bash
+# 1. Local dry run — parses + reports, NO network call. Confirms frontmatter/slugs are valid.
+python scripts/upload_docs.py --dry-run
+
+# 2. Commit, push to main (or open+merge a PR touching docs/), then trigger manually:
+gh workflow run upload-docs.yaml --repo <OWNER>/<REPO>
+
+# 3. Watch the run and confirm it succeeds (look for the per-batch "-> 200" lines / jobId in logs):
+gh run watch --repo <OWNER>/<REPO>
+gh run list --workflow upload-docs.yaml --repo <OWNER>/<REPO>
+```
+
+A green run with `-> 200` responses per batch means the docs are uploaded and ready on the docs service.
+
+## Reference: API contract
+
+- **Endpoint:** `POST {DOCS_ENDPOINT}/api/v1/docs/repositories/{urlencoded DOCS_REPOSITORY_ID}/documents`
+- **Auth:** `Authorization: Bearer {DOCS_UPLOAD_TOKEN}`
+- **Body:** `{"documents": [{"docId": "<slug>", "content": "<markdown body>"}, …]}` (≤ 50 per request)
+- **Token source:** `POST /api/v1/docs/repositories/[id]/upload-tokens` (github-pm) → `dput_…` / `dpat_…`
+
+## Troubleshooting
+
+- `no documents with slug frontmatter found` → no file under `docs/` has a `slug:` line. Add frontmatter.
+- `error: duplicate slug …` → two files share a slug. Make them unique.
+- `HTTP 401/403` → bad/missing token, or the secret isn't set. Re-run step 5; check `gh secret list`.
+- `HTTP 404` → wrong `DOCS_REPOSITORY_ID`, or the repository isn't registered on the docs service.
+- Workflow didn't trigger on push → your change didn't touch a path in the `paths:` filter. Edit a file under `docs/`, or run it manually with `workflow_dispatch`.

--- a/.claude/skills/docs-publishing/templates/upload-docs.yaml
+++ b/.claude/skills/docs-publishing/templates/upload-docs.yaml
@@ -1,0 +1,29 @@
+name: Upload docs to autopilot
+
+on:
+    push:
+        branches: ["main"]
+        paths:
+            - "docs/**"
+            - "scripts/upload_docs.py"
+            - ".github/workflows/upload-docs.yaml"
+    workflow_dispatch:
+
+concurrency:
+    group: upload-docs
+    cancel-in-progress: false
+
+jobs:
+    upload:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: "3.x"
+            - name: Upload docs
+              env:
+                  DOCS_ENDPOINT: https://autopilot.rxlab.app
+                  DOCS_REPOSITORY_ID: <OWNER>/<REPO>
+                  DOCS_UPLOAD_TOKEN: ${{ secrets.DOCS_UPLOAD_TOKEN }}
+              run: python scripts/upload_docs.py

--- a/.claude/skills/docs-publishing/templates/upload_docs.py
+++ b/.claude/skills/docs-publishing/templates/upload_docs.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Upload markdown docs to the autopilot docs API.
+
+Walks the docs directory, parses YAML frontmatter from each markdown file,
+and uploads files that declare a `slug` field as their document id.
+
+Usage:
+    DOCS_UPLOAD_TOKEN=dput_... DOCS_REPOSITORY_ID=repo_xxx \
+        python scripts/upload_docs.py
+
+    # dry run (no network call):
+    python scripts/upload_docs.py --dry-run
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+DEFAULT_ENDPOINT = "https://autopilot.rxlab.app"
+DEFAULT_DOCS_DIR = "docs"
+DEFAULT_BATCH_SIZE = 50
+
+
+def parse_frontmatter(text: str) -> tuple[dict, str]:
+    """Parse YAML frontmatter at the top of `text`. Returns (fields, body)."""
+    match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", text, re.DOTALL)
+    if not match:
+        return {}, text
+
+    fields: dict[str, str] = {}
+    for line in match.group(1).splitlines():
+        kv = re.match(r"^([A-Za-z_][\w-]*)\s*:\s*(.*?)\s*$", line)
+        if kv:
+            value = kv.group(2).strip()
+            if (value.startswith('"') and value.endswith('"')) or (
+                value.startswith("'") and value.endswith("'")
+            ):
+                value = value[1:-1]
+            fields[kv.group(1)] = value
+    return fields, match.group(2)
+
+
+def collect_docs(docs_dir: Path) -> list[dict]:
+    documents: list[dict] = []
+    seen: dict[str, Path] = {}
+
+    for md_file in sorted(docs_dir.rglob("*.md")):
+        text = md_file.read_text(encoding="utf-8")
+        fields, body = parse_frontmatter(text)
+        slug = fields.get("slug")
+        rel = md_file.relative_to(docs_dir)
+
+        if not slug:
+            print(f"skip {rel}: no `slug` in frontmatter", file=sys.stderr)
+            continue
+
+        if slug in seen:
+            print(
+                f"error: duplicate slug `{slug}` in {rel} and {seen[slug]}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        seen[slug] = rel
+
+        documents.append({"docId": slug, "content": body.lstrip("\n")})
+
+    return documents
+
+
+def upload_batch(url: str, token: str, batch: list[dict]) -> None:
+    payload = json.dumps({"documents": batch}).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+            print(f"  -> {resp.status} {body[:200]}")
+    except urllib.error.HTTPError as e:
+        err_body = e.read().decode("utf-8", errors="replace")
+        print(f"error: HTTP {e.code} {e.reason} — {err_body}", file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"error: request failed — {e.reason}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--docs-dir",
+        default=os.environ.get("DOCS_DIR", DEFAULT_DOCS_DIR),
+        help=f"directory containing markdown files (default: {DEFAULT_DOCS_DIR})",
+    )
+    parser.add_argument(
+        "--endpoint",
+        default=os.environ.get("DOCS_ENDPOINT", DEFAULT_ENDPOINT),
+        help=f"API base URL (default: {DEFAULT_ENDPOINT})",
+    )
+    parser.add_argument(
+        "--repo-id",
+        default=os.environ.get("DOCS_REPOSITORY_ID"),
+        help="docs repository id (env: DOCS_REPOSITORY_ID)",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("DOCS_UPLOAD_TOKEN"),
+        help="bearer token, dput_... or dpat_... (env: DOCS_UPLOAD_TOKEN)",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=DEFAULT_BATCH_SIZE,
+        help=f"docs per request (default: {DEFAULT_BATCH_SIZE})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="parse and report, but do not upload",
+    )
+    args = parser.parse_args()
+
+    docs_dir = Path(args.docs_dir)
+    if not docs_dir.is_dir():
+        print(f"error: docs dir not found: {docs_dir}", file=sys.stderr)
+        return 2
+
+    documents = collect_docs(docs_dir)
+    if not documents:
+        print("no documents with `slug` frontmatter found")
+        return 0
+
+    print(f"found {len(documents)} document(s):")
+    for d in documents:
+        print(f"  - {d['docId']} ({len(d['content'])} bytes)")
+
+    if args.dry_run:
+        return 0
+
+    if not args.repo_id:
+        print(
+            "error: --repo-id or DOCS_REPOSITORY_ID is required",
+            file=sys.stderr,
+        )
+        return 2
+    if not args.token:
+        print(
+            "error: --token or DOCS_UPLOAD_TOKEN is required",
+            file=sys.stderr,
+        )
+        return 2
+
+    repo_id_encoded = urllib.parse.quote(args.repo_id, safe="")
+    url = f"{args.endpoint.rstrip('/')}/api/v1/docs/repositories/{repo_id_encoded}/documents"
+    print(f"uploading to {url}")
+
+    for i in range(0, len(documents), args.batch_size):
+        batch = documents[i : i + args.batch_size]
+        print(f"batch {i // args.batch_size + 1}: {len(batch)} doc(s)")
+        upload_batch(url, args.token, batch)
+
+    print("done")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/e2e/trading/testhelper/mock_trading_provider.go
+++ b/e2e/trading/testhelper/mock_trading_provider.go
@@ -244,6 +244,67 @@ func (m *MockTradingProvider) GetAccountInfo() (types.AccountInfo, error) {
 	}, nil
 }
 
+// GetAssets returns simulated asset holdings derived from the mock's cash balance
+// and current positions. Zero-quantity assets are omitted.
+func (m *MockTradingProvider) GetAssets() ([]types.Asset, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	assets := make([]types.Asset, 0, len(m.positions)+1)
+
+	if m.balance > 0 {
+		assets = append(assets, types.Asset{
+			Symbol:            "USDT",
+			Quantity:          m.balance,
+			BaseCurrency:      "",
+			BaseCurrencyValue: nil,
+		})
+	}
+
+	for symbol, pos := range m.positions {
+		if pos.TotalLongPositionQuantity <= 0 {
+			continue
+		}
+
+		assets = append(assets, types.Asset{
+			Symbol:            symbol,
+			Quantity:          pos.TotalLongPositionQuantity,
+			BaseCurrency:      "",
+			BaseCurrencyValue: nil,
+		})
+	}
+
+	return assets, nil
+}
+
+// GetPrices returns the current price for each requested symbol from the
+// mock's in-memory price map. Symbols with no recorded price are omitted.
+func (m *MockTradingProvider) GetPrices(symbols []string) (map[string]float64, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if len(symbols) == 0 {
+		out := make(map[string]float64, len(m.currentPrice))
+		for symbol, price := range m.currentPrice {
+			if price > 0 {
+				out[symbol] = price
+			}
+		}
+
+		return out, nil
+	}
+
+	out := make(map[string]float64, len(symbols))
+
+	for _, symbol := range symbols {
+		if price, ok := m.currentPrice[symbol]; ok && price > 0 {
+			out[symbol] = price
+		}
+	}
+
+	return out, nil
+}
+
 // GetOpenOrders returns all open orders.
 func (m *MockTradingProvider) GetOpenOrders() ([]types.ExecuteOrder, error) {
 	m.mu.RLock()

--- a/internal/backtest/engine/engine_v1/backtest_trading.go
+++ b/internal/backtest/engine/engine_v1/backtest_trading.go
@@ -378,6 +378,51 @@ func (b *BacktestTrading) GetAccountInfo() (types.AccountInfo, error) {
 	}, nil
 }
 
+// GetAssets implements tradingprovider.TradingSystemProvider.
+// Returns simulated asset holdings derived from position quantities. Zero-quantity
+// assets are omitted. The cash balance is exposed as a USDT asset so callers that
+// pair this with USD conversion get the expected total.
+func (b *BacktestTrading) GetAssets() ([]types.Asset, error) {
+	positions, err := b.state.GetAllPositions()
+	if err != nil {
+		return nil, err
+	}
+
+	assets := make([]types.Asset, 0, len(positions)+1)
+
+	if b.balance > 0 {
+		assets = append(assets, types.Asset{
+			Symbol:            "USDT",
+			Quantity:          b.balance,
+			BaseCurrency:      "",
+			BaseCurrencyValue: nil,
+		})
+	}
+
+	for _, pos := range positions {
+		qty := pos.TotalLongPositionQuantity
+		if qty <= 0 {
+			continue
+		}
+
+		assets = append(assets, types.Asset{
+			Symbol:            pos.Symbol,
+			Quantity:          qty,
+			BaseCurrency:      "",
+			BaseCurrencyValue: nil,
+		})
+	}
+
+	return assets, nil
+}
+
+// GetPrices implements tradingprovider.TradingSystemProvider.
+// Backtest mode has no live ticker feed — prices are not available outside the
+// current bar. Returns an empty map so wallet conversions degrade gracefully.
+func (b *BacktestTrading) GetPrices(_ []string) (map[string]float64, error) {
+	return map[string]float64{}, nil
+}
+
 // GetOpenOrders implements tradingprovider.TradingSystemProvider.
 // Returns all pending/open orders that have not been executed yet.
 func (b *BacktestTrading) GetOpenOrders() ([]types.ExecuteOrder, error) {

--- a/internal/trading/engine/engine.go
+++ b/internal/trading/engine/engine.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/rxtech-lab/argo-trading/internal/runtime"
+	"github.com/rxtech-lab/argo-trading/internal/trading/wallet"
 	tradingprovider "github.com/rxtech-lab/argo-trading/internal/trading/provider"
 	"github.com/rxtech-lab/argo-trading/internal/types"
 	"github.com/rxtech-lab/argo-trading/pkg/marketdata/provider"
@@ -79,6 +80,25 @@ const (
 // surfaces matching the reported categories.
 type OnLiveDataChangedCallback func(runID string, categories []LiveTradingDataCategory, finalized bool, sequence int64) error
 
+// Wallet change callbacks are coalesced invalidation hints — they carry no
+// payload and signal that the consumer should re-fetch from the wallet API.
+// They fire only when the underlying value has changed since the previous tick
+// or order event.
+
+// OnOrderChangedCallback fires when an order is placed, filled, or its status
+// otherwise changes.
+type OnOrderChangedCallback func() error
+
+// OnBalanceChangedCallback fires when the combined value of all assets changes.
+type OnBalanceChangedCallback func() error
+
+// OnBuyingPowerChangedCallback fires when the broker-reported buying power changes.
+type OnBuyingPowerChangedCallback func() error
+
+// OnAssetsChangedCallback fires when the set of held assets or their quantities
+// changes.
+type OnAssetsChangedCallback func() error
+
 // LiveTradingCallbacks holds all lifecycle callback functions for the live trading engine.
 // All fields are pointers - nil means no callback will be invoked.
 type LiveTradingCallbacks struct {
@@ -121,6 +141,19 @@ type LiveTradingCallbacks struct {
 	// per-tick batch of persistence writes completes, and once more after the
 	// engine stops with finalized=true.
 	OnLiveDataChanged *OnLiveDataChangedCallback
+
+	// OnOrderChanged signals that the set of orders has changed (placed, filled,
+	// or status update) and the UI should re-fetch from the wallet API.
+	OnOrderChanged *OnOrderChangedCallback
+
+	// OnBalanceChanged signals that the combined value of all assets has changed.
+	OnBalanceChanged *OnBalanceChangedCallback
+
+	// OnBuyingPowerChanged signals that the broker-reported buying power has changed.
+	OnBuyingPowerChanged *OnBuyingPowerChangedCallback
+
+	// OnAssetsChanged signals that the set or quantities of held assets has changed.
+	OnAssetsChanged *OnAssetsChangedCallback
 }
 
 // PrefetchConfig holds configuration for historical data prefetching.
@@ -193,4 +226,10 @@ type LiveTradingEngine interface {
 
 	// GetConfigSchema returns the JSON schema for engine configuration.
 	GetConfigSchema() (string, error)
+
+	// Wallet returns a read-only wallet facade over the currently configured
+	// trading provider. Returns an error if no trading provider has been set.
+	// The wallet is callable outside Run() so the UI can show balance/assets
+	// without an active session.
+	Wallet() (wallet.Wallet, error)
 }

--- a/internal/trading/engine/engine_v1/live_trading_v1.go
+++ b/internal/trading/engine/engine_v1/live_trading_v1.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/rxtech-lab/argo-trading/internal/backtest/engine/engine_v1/cache"
 	"github.com/rxtech-lab/argo-trading/internal/backtest/engine/engine_v1/datasource"
@@ -19,6 +21,7 @@ import (
 	"github.com/rxtech-lab/argo-trading/internal/trading/engine/engine_v1/stats"
 	"github.com/rxtech-lab/argo-trading/internal/trading/engine/engine_v1/writers"
 	tradingprovider "github.com/rxtech-lab/argo-trading/internal/trading/provider"
+	"github.com/rxtech-lab/argo-trading/internal/trading/wallet"
 	"github.com/rxtech-lab/argo-trading/internal/types"
 	"github.com/rxtech-lab/argo-trading/internal/version"
 	"github.com/rxtech-lab/argo-trading/pkg/errors"
@@ -623,6 +626,14 @@ func (e *LiveTradingEngineV1) Run(ctx context.Context, callbacks engine.LiveTrad
 	persistedLogs := 0
 	persistedMarks := 0
 
+	// Wallet snapshot for change-detection across ticks. Only populated when at
+	// least one wallet callback is registered — otherwise we skip the extra
+	// broker round-trips entirely.
+	var walletState *walletSnapshot
+	if walletEventsRegistered(callbacks) {
+		walletState = e.emitWalletEvents(nil, callbacks)
+	}
+
 	// Process each market data point from the stream
 	for data, err := range stream {
 		// Check for context cancellation
@@ -815,6 +826,12 @@ func (e *LiveTradingEngineV1) Run(ctx context.Context, callbacks engine.LiveTrad
 
 		// Emit coalesced reload hint after all per-tick persistence writes.
 		emitDataChanged(changedCategories, false)
+
+		// Diff broker-reported wallet state against the previous tick and fire
+		// any change callbacks. Skipped when no wallet callbacks are registered.
+		if walletEventsRegistered(callbacks) {
+			walletState = e.emitWalletEvents(walletState, callbacks)
+		}
 	}
 
 	// After stream ends, check if it was due to context cancellation
@@ -830,6 +847,175 @@ func (e *LiveTradingEngineV1) Run(ctx context.Context, callbacks engine.LiveTrad
 // GetConfigSchema implements engine.LiveTradingEngine.
 func (e *LiveTradingEngineV1) GetConfigSchema() (string, error) {
 	return engine.GetConfigSchema()
+}
+
+// Wallet implements engine.LiveTradingEngine. The returned facade reads from the
+// currently configured trading provider on every call — it is safe to use both
+// inside and outside Run(). Asset valuation goes through the provider's batch
+// price API, not the streaming bar cache, so prices are correct even for
+// symbols the engine is not currently subscribed to.
+func (e *LiveTradingEngineV1) Wallet() (wallet.Wallet, error) {
+	if e.tradingProvider == nil {
+		return nil, errors.New(errors.ErrCodeBacktestInitFailed, "trading provider not set - call SetTradingProvider() first")
+	}
+
+	return wallet.New(wallet.Config{
+		Provider: e.tradingProvider,
+	})
+}
+
+// walletSnapshot captures the wallet fields tracked across ticks for change
+// detection. Asset quantities are keyed by symbol so we only fire OnAssetsChanged
+// when the set or quantity actually moves.
+type walletSnapshot struct {
+	balance        float64
+	buyingPower    float64
+	assets         map[string]float64
+	openOrdersHash string
+}
+
+// emitWalletEvents reads the current account info, assets, and open orders from
+// the provider, compares against prev, and invokes the matching callbacks for
+// the values that changed. Returns the new snapshot so the caller can persist it
+// for the next diff. Callers must skip the call entirely when none of the
+// wallet callbacks are registered to avoid the extra broker round-trips.
+func (e *LiveTradingEngineV1) emitWalletEvents(prev *walletSnapshot, callbacks engine.LiveTradingCallbacks) *walletSnapshot {
+	current := &walletSnapshot{
+		balance:        prev.copyBalance(),
+		buyingPower:    prev.copyBuyingPower(),
+		assets:         prev.copyAssets(),
+		openOrdersHash: prev.copyOpenOrdersHash(),
+	}
+
+	if callbacks.OnBalanceChanged != nil || callbacks.OnBuyingPowerChanged != nil {
+		info, err := e.tradingProvider.GetAccountInfo()
+		if err != nil {
+			e.log.Warn("wallet snapshot: GetAccountInfo failed", zap.Error(err))
+		} else {
+			current.balance = info.Balance
+			current.buyingPower = info.BuyingPower
+		}
+	}
+
+	if callbacks.OnAssetsChanged != nil {
+		rawAssets, err := e.tradingProvider.GetAssets()
+		if err != nil {
+			e.log.Warn("wallet snapshot: GetAssets failed", zap.Error(err))
+		} else {
+			current.assets = make(map[string]float64, len(rawAssets))
+			for _, a := range rawAssets {
+				current.assets[a.Symbol] = a.Quantity
+			}
+		}
+	}
+
+	if callbacks.OnOrderChanged != nil {
+		openOrders, err := e.tradingProvider.GetOpenOrders()
+		if err != nil {
+			e.log.Warn("wallet snapshot: GetOpenOrders failed", zap.Error(err))
+		} else {
+			current.openOrdersHash = hashOpenOrders(openOrders)
+		}
+	}
+
+	if prev == nil {
+		return current
+	}
+
+	if callbacks.OnBalanceChanged != nil && prev.balance != current.balance {
+		if err := (*callbacks.OnBalanceChanged)(); err != nil {
+			e.log.Warn("OnBalanceChanged callback failed", zap.Error(err))
+		}
+	}
+
+	if callbacks.OnBuyingPowerChanged != nil && prev.buyingPower != current.buyingPower {
+		if err := (*callbacks.OnBuyingPowerChanged)(); err != nil {
+			e.log.Warn("OnBuyingPowerChanged callback failed", zap.Error(err))
+		}
+	}
+
+	if callbacks.OnAssetsChanged != nil && !assetMapsEqual(prev.assets, current.assets) {
+		if err := (*callbacks.OnAssetsChanged)(); err != nil {
+			e.log.Warn("OnAssetsChanged callback failed", zap.Error(err))
+		}
+	}
+
+	if callbacks.OnOrderChanged != nil && prev.openOrdersHash != current.openOrdersHash {
+		if err := (*callbacks.OnOrderChanged)(); err != nil {
+			e.log.Warn("OnOrderChanged callback failed", zap.Error(err))
+		}
+	}
+
+	return current
+}
+
+// walletEventsRegistered reports whether any wallet-related callback is wired
+// up. When false the engine skips the per-tick broker calls used for diffing.
+func walletEventsRegistered(c engine.LiveTradingCallbacks) bool {
+	return c.OnBalanceChanged != nil || c.OnBuyingPowerChanged != nil ||
+		c.OnAssetsChanged != nil || c.OnOrderChanged != nil
+}
+
+// hashOpenOrders produces a stable string from the open-order set used purely
+// for change detection — not a security hash.
+func hashOpenOrders(orders []types.ExecuteOrder) string {
+	ids := make([]string, 0, len(orders))
+	for _, o := range orders {
+		ids = append(ids, o.ID)
+	}
+	sort.Strings(ids)
+
+	return fmt.Sprintf("%d:%s", len(ids), strings.Join(ids, ","))
+}
+
+func (s *walletSnapshot) copyBalance() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return s.balance
+}
+
+func (s *walletSnapshot) copyBuyingPower() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return s.buyingPower
+}
+
+func (s *walletSnapshot) copyAssets() map[string]float64 {
+	if s == nil {
+		return nil
+	}
+
+	out := make(map[string]float64, len(s.assets))
+	for k, v := range s.assets {
+		out[k] = v
+	}
+
+	return out
+}
+
+func (s *walletSnapshot) copyOpenOrdersHash() string {
+	if s == nil {
+		return ""
+	}
+
+	return s.openOrdersHash
+}
+
+func assetMapsEqual(a, b map[string]float64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if other, ok := b[k]; !ok || other != v {
+			return false
+		}
+	}
+
+	return true
 }
 
 // preRunCheck validates that all required components are configured before running.

--- a/internal/trading/provider/binance.go
+++ b/internal/trading/provider/binance.go
@@ -74,6 +74,13 @@ type TradeFeeService interface {
 	Do(ctx context.Context) ([]*binance.TradeFeeDetails, error)
 }
 
+// ListPricesService interface for fetching ticker prices in batch via
+// GET /api/v3/ticker/price. Pass an empty symbol list to fetch all pairs.
+type ListPricesService interface {
+	Symbols(symbols []string) ListPricesService
+	Do(ctx context.Context) ([]*binance.SymbolPrice, error)
+}
+
 // BinanceClient interface abstracts the Binance client for testing.
 type BinanceClient interface {
 	NewCreateOrderService() CreateOrderService
@@ -83,6 +90,7 @@ type BinanceClient interface {
 	NewCancelOpenOrdersService() CancelOpenOrdersService
 	NewListTradesService() ListTradesService
 	NewTradeFeeService() TradeFeeService
+	NewListPricesService() ListPricesService
 }
 
 // realBinanceClient wraps the actual binance.Client.
@@ -116,6 +124,10 @@ func (r *realBinanceClient) NewListTradesService() ListTradesService {
 
 func (r *realBinanceClient) NewTradeFeeService() TradeFeeService {
 	return &realTradeFeeService{service: r.client.NewTradeFeeService()}
+}
+
+func (r *realBinanceClient) NewListPricesService() ListPricesService {
+	return &realListPricesService{service: r.client.NewListPricesService()}
 }
 
 // Real service wrappers
@@ -259,6 +271,20 @@ func (s *realTradeFeeService) Symbol(symbol string) TradeFeeService {
 }
 
 func (s *realTradeFeeService) Do(ctx context.Context) ([]*binance.TradeFeeDetails, error) {
+	return s.service.Do(ctx)
+}
+
+type realListPricesService struct {
+	service *binance.ListPricesService
+}
+
+func (s *realListPricesService) Symbols(symbols []string) ListPricesService {
+	s.service = s.service.Symbols(symbols)
+
+	return s
+}
+
+func (s *realListPricesService) Do(ctx context.Context) ([]*binance.SymbolPrice, error) {
 	return s.service.Do(ctx)
 }
 
@@ -596,6 +622,69 @@ func (b *BinanceTradingSystemProvider) GetAccountInfo() (types.AccountInfo, erro
 		TotalFees:     0, // Not directly available from account info
 		MarginUsed:    0, // Not applicable for spot
 	}, nil
+}
+
+// GetAssets returns all asset balances reported by the broker (free + locked).
+// Zero-quantity assets are omitted.
+func (b *BinanceTradingSystemProvider) GetAssets() ([]types.Asset, error) {
+	ctx := context.Background()
+
+	account, err := b.client.NewGetAccountService().Do(ctx)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeOrderFailed, "failed to get account info from Binance", err)
+	}
+
+	assets := make([]types.Asset, 0, len(account.Balances))
+
+	for _, balance := range account.Balances {
+		free, _ := strconv.ParseFloat(balance.Free, 64)
+		locked, _ := strconv.ParseFloat(balance.Locked, 64)
+		total := free + locked
+
+		if total <= 0 {
+			continue
+		}
+
+		assets = append(assets, types.Asset{
+			Symbol:            balance.Asset,
+			Quantity:          total,
+			BaseCurrency:      "",
+			BaseCurrencyValue: nil,
+		})
+	}
+
+	return assets, nil
+}
+
+// GetPrices returns the latest ticker price for each requested trading pair via
+// GET /api/v3/ticker/price. Symbols not returned by the API (e.g. unsupported
+// pairs like USDTUSDT) are omitted from the map. Pass an empty slice to fetch
+// every pair the exchange tracks.
+func (b *BinanceTradingSystemProvider) GetPrices(symbols []string) (map[string]float64, error) {
+	ctx := context.Background()
+
+	service := b.client.NewListPricesService()
+	if len(symbols) > 0 {
+		service = service.Symbols(symbols)
+	}
+
+	prices, err := service.Do(ctx)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeOrderFailed, "failed to get prices from Binance", err)
+	}
+
+	out := make(map[string]float64, len(prices))
+
+	for _, p := range prices {
+		price, parseErr := strconv.ParseFloat(p.Price, 64)
+		if parseErr != nil || price <= 0 {
+			continue
+		}
+
+		out[p.Symbol] = price
+	}
+
+	return out, nil
 }
 
 // GetOpenOrders returns all pending/open orders.

--- a/internal/trading/provider/binance_test.go
+++ b/internal/trading/provider/binance_test.go
@@ -22,6 +22,7 @@ type mockBinanceClient struct {
 	cancelOpenOrdersService *mockCancelOpenOrdersService
 	listTradesService       *mockListTradesService
 	tradeFeeService         *mockTradeFeeService
+	listPricesService       *mockListPricesService
 }
 
 func newMockBinanceClient() *mockBinanceClient {
@@ -33,6 +34,7 @@ func newMockBinanceClient() *mockBinanceClient {
 		cancelOpenOrdersService: &mockCancelOpenOrdersService{},
 		listTradesService:       &mockListTradesService{},
 		tradeFeeService:         &mockTradeFeeService{},
+		listPricesService:       &mockListPricesService{},
 	}
 }
 
@@ -62,6 +64,10 @@ func (m *mockBinanceClient) NewListTradesService() ListTradesService {
 
 func (m *mockBinanceClient) NewTradeFeeService() TradeFeeService {
 	return m.tradeFeeService
+}
+
+func (m *mockBinanceClient) NewListPricesService() ListPricesService {
+	return m.listPricesService
 }
 
 // mockCreateOrderService implements CreateOrderService
@@ -215,6 +221,22 @@ func (m *mockTradeFeeService) Symbol(symbol string) TradeFeeService {
 
 func (m *mockTradeFeeService) Do(_ context.Context) ([]*binance.TradeFeeDetails, error) {
 	return m.fees, m.err
+}
+
+// mockListPricesService implements ListPricesService.
+type mockListPricesService struct {
+	prices  []*binance.SymbolPrice
+	err     error
+	symbols []string
+}
+
+func (m *mockListPricesService) Symbols(symbols []string) ListPricesService {
+	m.symbols = symbols
+	return m
+}
+
+func (m *mockListPricesService) Do(_ context.Context) ([]*binance.SymbolPrice, error) {
+	return m.prices, m.err
 }
 
 type BinanceTradingTestSuite struct {

--- a/internal/trading/provider/logging_provider.go
+++ b/internal/trading/provider/logging_provider.go
@@ -103,6 +103,21 @@ func (p *LoggingTradingSystemProvider) GetAccountInfo() (types.AccountInfo, erro
 	return p.inner.GetAccountInfo()
 }
 
+func (p *LoggingTradingSystemProvider) GetAssets() ([]types.Asset, error) {
+	p.log.Info("strategy wants to call api", zap.String("api", "GetAssets"))
+
+	return p.inner.GetAssets()
+}
+
+func (p *LoggingTradingSystemProvider) GetPrices(symbols []string) (map[string]float64, error) {
+	p.log.Info("strategy wants to call api",
+		zap.String("api", "GetPrices"),
+		zap.Int("count", len(symbols)),
+	)
+
+	return p.inner.GetPrices(symbols)
+}
+
 func (p *LoggingTradingSystemProvider) GetOpenOrders() ([]types.ExecuteOrder, error) {
 	p.log.Info("strategy wants to call api", zap.String("api", "GetOpenOrders"))
 

--- a/internal/trading/provider/trading_system_provider.go
+++ b/internal/trading/provider/trading_system_provider.go
@@ -28,6 +28,14 @@ type TradingSystemProvider interface {
 	GetOrderStatus(orderID string) (types.OrderStatus, error)
 	// GetAccountInfo returns the current account state including balance, equity, and P&L
 	GetAccountInfo() (types.AccountInfo, error)
+	// GetAssets returns the raw asset balances reported by the broker (free + locked),
+	// without base-currency conversion. Zero-quantity assets are omitted.
+	GetAssets() ([]types.Asset, error)
+	// GetPrices returns the latest price for each requested trading pair, keyed
+	// on the broker's pair symbol (e.g. "BTCUSDT" -> 65000.0). Symbols the broker
+	// does not know are simply omitted from the map. Pass an empty slice to
+	// fetch every pair the broker tracks.
+	GetPrices(symbols []string) (map[string]float64, error)
 	// GetOpenOrders returns all pending/open orders that have not been executed yet
 	GetOpenOrders() ([]types.ExecuteOrder, error)
 	// GetTrades returns executed trades with optional filtering

--- a/internal/trading/wallet/wallet.go
+++ b/internal/trading/wallet/wallet.go
@@ -1,0 +1,233 @@
+// Package wallet exposes a read-only facade over a TradingSystemProvider that
+// returns live balance, asset holdings, and historical orders straight from the
+// broker. Used by the iOS bridge so the wallet UI does not have to read parquet
+// files written by the engine.
+package wallet
+
+import (
+	"fmt"
+	"strings"
+
+	tradingprovider "github.com/rxtech-lab/argo-trading/internal/trading/provider"
+	"github.com/rxtech-lab/argo-trading/internal/types"
+)
+
+// BaseCurrencyUSD is the only base currency supported today. Conversions for
+// other values are rejected with an error.
+const BaseCurrencyUSD = "USD"
+
+// quoteSymbolUSD is the broker-side quote ticker that maps to USD. Binance
+// quotes USD-denominated pairs against USDT, so converting an asset to USD
+// means looking up the `<asset>USDT` ticker price.
+const quoteSymbolUSD = "USDT"
+
+// supportedBaseCurrencies is the static list returned by GetSupportedBaseCurrencies.
+var supportedBaseCurrencies = []string{BaseCurrencyUSD}
+
+// Wallet is the read-only API exposed to the UI.
+type Wallet interface {
+	// GetBalance returns either the cash buying power or the combined value of
+	// all assets, expressed in baseCurrency. Pass "" to default to USD.
+	GetBalance(balanceType types.BalanceType, baseCurrency string) (types.Balance, error)
+
+	// GetAssets returns every non-zero asset holding reported by the broker. When
+	// baseCurrency is non-empty, each asset is populated with its converted value
+	// (nil when no price is available from the broker for that pair).
+	GetAssets(baseCurrency string) ([]types.Asset, error)
+
+	// GetHistoricalOrders returns executed trades from the broker (not from the
+	// local parquet writers).
+	GetHistoricalOrders(filter types.TradeFilter) ([]types.Trade, error)
+
+	// GetSupportedBaseCurrencies lists the base currencies accepted by
+	// GetBalance/GetAssets.
+	GetSupportedBaseCurrencies() []string
+}
+
+// Config holds the dependencies for a Wallet.
+type Config struct {
+	// Provider is the trading provider whose broker is queried for live data.
+	// Required.
+	Provider tradingprovider.TradingSystemProvider
+}
+
+type wallet struct {
+	provider tradingprovider.TradingSystemProvider
+}
+
+// New builds a Wallet. Returns an error if Provider is nil.
+func New(cfg Config) (Wallet, error) {
+	if cfg.Provider == nil {
+		return nil, fmt.Errorf("wallet: provider is required")
+	}
+
+	return &wallet{
+		provider: cfg.Provider,
+	}, nil
+}
+
+// GetSupportedBaseCurrencies implements Wallet.
+func (w *wallet) GetSupportedBaseCurrencies() []string {
+	out := make([]string, len(supportedBaseCurrencies))
+	copy(out, supportedBaseCurrencies)
+
+	return out
+}
+
+// GetBalance implements Wallet.
+func (w *wallet) GetBalance(balanceType types.BalanceType, baseCurrency string) (types.Balance, error) {
+	normalized, err := normalizeBaseCurrency(baseCurrency)
+	if err != nil {
+		return types.Balance{}, err
+	}
+
+	switch balanceType {
+	case types.BalanceTypeBuyingPower:
+		info, err := w.provider.GetAccountInfo()
+		if err != nil {
+			return types.Balance{}, err
+		}
+
+		return types.Balance{
+			Type:         types.BalanceTypeBuyingPower,
+			Value:        info.BuyingPower,
+			BaseCurrency: normalized,
+		}, nil
+	case types.BalanceTypeBalance:
+		assets, err := w.GetAssets(normalized)
+		if err != nil {
+			return types.Balance{}, err
+		}
+
+		var total float64
+		for _, asset := range assets {
+			if asset.BaseCurrencyValue != nil {
+				total += *asset.BaseCurrencyValue
+			}
+		}
+
+		return types.Balance{
+			Type:         types.BalanceTypeBalance,
+			Value:        total,
+			BaseCurrency: normalized,
+		}, nil
+	default:
+		return types.Balance{}, fmt.Errorf("wallet: unsupported balance type %q", balanceType)
+	}
+}
+
+// GetAssets implements Wallet.
+func (w *wallet) GetAssets(baseCurrency string) ([]types.Asset, error) {
+	assets, err := w.provider.GetAssets()
+	if err != nil {
+		return nil, err
+	}
+
+	if baseCurrency == "" {
+		return assets, nil
+	}
+
+	normalized, err := normalizeBaseCurrency(baseCurrency)
+	if err != nil {
+		return nil, err
+	}
+
+	quote := quoteSymbolFor(normalized)
+
+	// Build the broker-side pair list for every asset that needs pricing.
+	// Assets whose symbol already equals the quote (e.g. USDT when pricing in
+	// USD) skip the API call — there is no `<quote><quote>` ticker.
+	pairs := make([]string, 0, len(assets))
+	pairBySymbol := make(map[string]string, len(assets))
+
+	for _, asset := range assets {
+		upper := strings.ToUpper(asset.Symbol)
+		if upper == quote {
+			continue
+		}
+
+		pair := upper + quote
+		pairBySymbol[upper] = pair
+		pairs = append(pairs, pair)
+	}
+
+	prices := map[string]float64{}
+
+	if len(pairs) > 0 {
+		var pricesErr error
+
+		prices, pricesErr = w.provider.GetPrices(pairs)
+		if pricesErr != nil {
+			return nil, pricesErr
+		}
+	}
+
+	for i := range assets {
+		assets[i].BaseCurrency = normalized
+		assets[i].BaseCurrencyValue = valueFor(assets[i].Symbol, assets[i].Quantity, quote, pairBySymbol, prices)
+	}
+
+	return assets, nil
+}
+
+// GetHistoricalOrders implements Wallet.
+func (w *wallet) GetHistoricalOrders(filter types.TradeFilter) ([]types.Trade, error) {
+	return w.provider.GetTrades(filter)
+}
+
+// valueFor returns the asset's value in the base currency. The base currency
+// is identified by its broker-side quote symbol (e.g. "USDT" for USD). Returns
+// nil when the broker has no price for the constructed pair.
+func valueFor(symbol string, quantity float64, quote string, pairBySymbol map[string]string, prices map[string]float64) *float64 {
+	upper := strings.ToUpper(symbol)
+
+	// The asset is already denominated in the quote currency — no API price
+	// exists for `<quote><quote>`, so the value is the quantity itself.
+	if upper == quote {
+		v := quantity
+
+		return &v
+	}
+
+	pair, ok := pairBySymbol[upper]
+	if !ok {
+		return nil
+	}
+
+	price, ok := prices[pair]
+	if !ok || price <= 0 {
+		return nil
+	}
+
+	v := quantity * price
+
+	return &v
+}
+
+// quoteSymbolFor returns the broker-side ticker that represents baseCurrency.
+// baseCurrency is assumed to already be normalized (e.g. "USD").
+func quoteSymbolFor(baseCurrency string) string {
+	if baseCurrency == BaseCurrencyUSD {
+		return quoteSymbolUSD
+	}
+
+	return baseCurrency
+}
+
+// normalizeBaseCurrency uppercases the input and rejects unsupported values.
+// An empty input defaults to USD.
+func normalizeBaseCurrency(baseCurrency string) (string, error) {
+	if baseCurrency == "" {
+		return BaseCurrencyUSD, nil
+	}
+
+	upper := strings.ToUpper(baseCurrency)
+	for _, supported := range supportedBaseCurrencies {
+		if upper == supported {
+			return upper, nil
+		}
+	}
+
+	return "", fmt.Errorf("wallet: unsupported base currency %q (supported: %s)",
+		baseCurrency, strings.Join(supportedBaseCurrencies, ", "))
+}

--- a/internal/trading/wallet/wallet_test.go
+++ b/internal/trading/wallet/wallet_test.go
@@ -1,0 +1,236 @@
+package wallet
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	tradingprovider "github.com/rxtech-lab/argo-trading/internal/trading/provider"
+	"github.com/rxtech-lab/argo-trading/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+// noopProvider satisfies tradingprovider.TradingSystemProvider for the methods
+// the wallet never calls in these tests.
+type noopProvider struct{}
+
+func (noopProvider) PlaceOrder(types.ExecuteOrder) error                  { return nil }
+func (noopProvider) PlaceMultipleOrders([]types.ExecuteOrder) error       { return nil }
+func (noopProvider) GetPositions() ([]types.Position, error)              { return nil, nil }
+func (noopProvider) GetPosition(string) (types.Position, error)           { return types.Position{}, nil }
+func (noopProvider) CancelOrder(string) error                             { return nil }
+func (noopProvider) CancelAllOrders() error                               { return nil }
+func (noopProvider) GetOrderStatus(string) (types.OrderStatus, error)     { return "", nil }
+func (noopProvider) GetAccountInfo() (types.AccountInfo, error)           { return types.AccountInfo{}, nil }
+func (noopProvider) GetAssets() ([]types.Asset, error)                    { return nil, nil }
+func (noopProvider) GetPrices([]string) (map[string]float64, error)       { return nil, nil }
+func (noopProvider) GetOpenOrders() ([]types.ExecuteOrder, error)         { return nil, nil }
+func (noopProvider) GetTrades(types.TradeFilter) ([]types.Trade, error)   { return nil, nil }
+func (noopProvider) GetMaxBuyQuantity(string, float64) (float64, error)   { return 0, nil }
+func (noopProvider) GetMaxSellQuantity(string) (float64, error)           { return 0, nil }
+func (noopProvider) CheckConnection(context.Context) error                { return nil }
+func (noopProvider) SetOnStatusChange(tradingprovider.OnStatusChange)     {}
+
+// fakeProvider satisfies just enough of TradingSystemProvider for wallet tests
+// — the wallet only calls GetAccountInfo, GetAssets, GetPrices, and GetTrades.
+type fakeProvider struct {
+	account    types.AccountInfo
+	accountErr error
+	assets     []types.Asset
+	assetsErr  error
+	prices     map[string]float64
+	pricesErr  error
+	pricesReq  []string
+	trades     []types.Trade
+	tradesErr  error
+	lastFilter types.TradeFilter
+}
+
+func newTestWallet(t *testing.T, p *fakeProvider) Wallet {
+	t.Helper()
+
+	w, err := New(Config{
+		Provider: &walletProviderAdapter{inner: p},
+	})
+	require.NoError(t, err)
+
+	return w
+}
+
+func TestGetSupportedBaseCurrencies(t *testing.T) {
+	w := newTestWallet(t, &fakeProvider{})
+
+	got := w.GetSupportedBaseCurrencies()
+	require.Equal(t, []string{"USD"}, got)
+}
+
+func TestGetBalance_BuyingPower(t *testing.T) {
+	p := &fakeProvider{account: types.AccountInfo{BuyingPower: 1234.5}}
+	w := newTestWallet(t, p)
+
+	bal, err := w.GetBalance(types.BalanceTypeBuyingPower, "")
+	require.NoError(t, err)
+	require.Equal(t, types.BalanceTypeBuyingPower, bal.Type)
+	require.Equal(t, "USD", bal.BaseCurrency)
+	require.InDelta(t, 1234.5, bal.Value, 1e-9)
+}
+
+func TestGetBalance_BuyingPower_PropagatesError(t *testing.T) {
+	p := &fakeProvider{accountErr: errors.New("boom")}
+	w := newTestWallet(t, p)
+
+	_, err := w.GetBalance(types.BalanceTypeBuyingPower, "USD")
+	require.ErrorContains(t, err, "boom")
+}
+
+func TestGetBalance_TotalSumsAssetValues(t *testing.T) {
+	p := &fakeProvider{
+		assets: []types.Asset{
+			{Symbol: "USDT", Quantity: 100},
+			{Symbol: "BTC", Quantity: 0.5},
+			{Symbol: "DOGE", Quantity: 200}, // no price -> skipped
+		},
+		prices: map[string]float64{"BTCUSDT": 50000},
+	}
+	w := newTestWallet(t, p)
+
+	bal, err := w.GetBalance(types.BalanceTypeBalance, "USD")
+	require.NoError(t, err)
+	require.Equal(t, types.BalanceTypeBalance, bal.Type)
+	require.Equal(t, "USD", bal.BaseCurrency)
+	require.InDelta(t, 100+0.5*50000, bal.Value, 1e-9)
+}
+
+func TestGetBalance_UnsupportedType(t *testing.T) {
+	w := newTestWallet(t, &fakeProvider{})
+
+	_, err := w.GetBalance("nope", "")
+	require.ErrorContains(t, err, "unsupported balance type")
+}
+
+func TestGetBalance_UnsupportedCurrency(t *testing.T) {
+	w := newTestWallet(t, &fakeProvider{})
+
+	_, err := w.GetBalance(types.BalanceTypeBuyingPower, "EUR")
+	require.ErrorContains(t, err, "unsupported base currency")
+}
+
+func TestGetAssets_NoConversionRequested(t *testing.T) {
+	p := &fakeProvider{assets: []types.Asset{{Symbol: "USDT", Quantity: 10}}}
+	w := newTestWallet(t, p)
+
+	got, err := w.GetAssets("")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Empty(t, got[0].BaseCurrency)
+	require.Nil(t, got[0].BaseCurrencyValue)
+	require.Empty(t, p.pricesReq, "no conversion -> no GetPrices call")
+}
+
+func TestGetAssets_USDConversion(t *testing.T) {
+	p := &fakeProvider{
+		assets: []types.Asset{
+			{Symbol: "USDT", Quantity: 50},
+			{Symbol: "BTC", Quantity: 2},
+			{Symbol: "USDC", Quantity: 25},
+			{Symbol: "ZZZ", Quantity: 1}, // no API price
+		},
+		prices: map[string]float64{
+			"BTCUSDT":  30000,
+			"USDCUSDT": 0.9999,
+		},
+	}
+	w := newTestWallet(t, p)
+
+	got, err := w.GetAssets("USD")
+	require.NoError(t, err)
+	require.Len(t, got, 4)
+
+	byName := map[string]types.Asset{}
+	for _, a := range got {
+		byName[a.Symbol] = a
+	}
+
+	// USDT is the quote unit -> value == quantity (no API call).
+	require.NotNil(t, byName["USDT"].BaseCurrencyValue)
+	require.InDelta(t, 50, *byName["USDT"].BaseCurrencyValue, 1e-9)
+
+	require.NotNil(t, byName["BTC"].BaseCurrencyValue)
+	require.InDelta(t, 60000, *byName["BTC"].BaseCurrencyValue, 1e-9)
+
+	// USDC uses the actual API price (no longer assumed = 1).
+	require.NotNil(t, byName["USDC"].BaseCurrencyValue)
+	require.InDelta(t, 25*0.9999, *byName["USDC"].BaseCurrencyValue, 1e-9)
+
+	require.Nil(t, byName["ZZZ"].BaseCurrencyValue, "no broker price -> nil value")
+
+	require.ElementsMatch(t, []string{"BTCUSDT", "USDCUSDT", "ZZZUSDT"}, p.pricesReq,
+		"wallet batches all non-quote symbols into a single GetPrices call")
+}
+
+func TestGetAssets_PricesErrorPropagates(t *testing.T) {
+	p := &fakeProvider{
+		assets:    []types.Asset{{Symbol: "BTC", Quantity: 1}},
+		pricesErr: errors.New("rate limited"),
+	}
+	w := newTestWallet(t, p)
+
+	_, err := w.GetAssets("USD")
+	require.ErrorContains(t, err, "rate limited")
+}
+
+func TestGetAssets_OnlyQuoteAssetSkipsAPI(t *testing.T) {
+	p := &fakeProvider{
+		assets: []types.Asset{{Symbol: "USDT", Quantity: 7}},
+	}
+	w := newTestWallet(t, p)
+
+	got, err := w.GetAssets("USD")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.NotNil(t, got[0].BaseCurrencyValue)
+	require.InDelta(t, 7, *got[0].BaseCurrencyValue, 1e-9)
+	require.Empty(t, p.pricesReq, "only quote asset -> no GetPrices call")
+}
+
+func TestGetAssets_CaseInsensitiveCurrency(t *testing.T) {
+	p := &fakeProvider{assets: []types.Asset{{Symbol: "USDT", Quantity: 1}}}
+	w := newTestWallet(t, p)
+
+	got, err := w.GetAssets("usd")
+	require.NoError(t, err)
+	require.Equal(t, "USD", got[0].BaseCurrency)
+}
+
+func TestGetHistoricalOrders_PassthroughFilter(t *testing.T) {
+	wantTrades := []types.Trade{{ExecutedQty: 1.0}}
+	p := &fakeProvider{trades: wantTrades}
+	w := newTestWallet(t, p)
+
+	got, err := w.GetHistoricalOrders(types.TradeFilter{Symbol: "BTCUSDT", Limit: 5})
+	require.NoError(t, err)
+	require.Equal(t, wantTrades, got)
+}
+
+// walletProviderAdapter wraps fakeProvider into the full
+// tradingprovider.TradingSystemProvider interface by embedding noopProvider for
+// methods the wallet never calls.
+type walletProviderAdapter struct {
+	noopProvider
+	inner *fakeProvider
+}
+
+func (a *walletProviderAdapter) GetAccountInfo() (types.AccountInfo, error) {
+	return a.inner.account, a.inner.accountErr
+}
+func (a *walletProviderAdapter) GetAssets() ([]types.Asset, error) {
+	return a.inner.assets, a.inner.assetsErr
+}
+func (a *walletProviderAdapter) GetPrices(symbols []string) (map[string]float64, error) {
+	a.inner.pricesReq = append([]string(nil), symbols...)
+	return a.inner.prices, a.inner.pricesErr
+}
+func (a *walletProviderAdapter) GetTrades(filter types.TradeFilter) ([]types.Trade, error) {
+	a.inner.lastFilter = filter
+	return a.inner.trades, a.inner.tradesErr
+}

--- a/internal/types/wallet.go
+++ b/internal/types/wallet.go
@@ -1,0 +1,33 @@
+package types
+
+// Asset represents a single asset holding reported by the broker.
+type Asset struct {
+	// Symbol is the asset ticker as reported by the broker (e.g. "BTC", "USDT").
+	Symbol string `json:"symbol" yaml:"symbol"`
+	// Quantity is the total balance for the asset (free + locked).
+	Quantity float64 `json:"quantity" yaml:"quantity"`
+	// BaseCurrency is the currency the asset is valued in. Empty when no
+	// conversion was requested.
+	BaseCurrency string `json:"base_currency,omitempty" yaml:"base_currency,omitempty"`
+	// BaseCurrencyValue is the asset's value expressed in BaseCurrency. Nil
+	// when conversion was not requested or no price was available.
+	BaseCurrencyValue *float64 `json:"base_currency_value,omitempty" yaml:"base_currency_value,omitempty"`
+}
+
+// BalanceType selects which balance figure to return from Wallet.GetBalance.
+type BalanceType string
+
+const (
+	// BalanceTypeBuyingPower returns the cash currently available for new orders.
+	BalanceTypeBuyingPower BalanceType = "buying_power"
+	// BalanceTypeBalance returns the combined value of all assets (cash + holdings)
+	// expressed in the requested base currency.
+	BalanceTypeBalance BalanceType = "balance"
+)
+
+// Balance is the response payload for Wallet.GetBalance.
+type Balance struct {
+	Type         BalanceType `json:"type" yaml:"type"`
+	Value        float64     `json:"value" yaml:"value"`
+	BaseCurrency string      `json:"base_currency" yaml:"base_currency"`
+}

--- a/pkg/swift-argo/trading.go
+++ b/pkg/swift-argo/trading.go
@@ -74,6 +74,23 @@ type TradingEngineHelper interface {
 	// Consumers should debounce reloads (e.g. ~500ms) and only refresh the
 	// surfaces matching the reported categories.
 	OnLiveDataChanged(runId string, categories StringCollection, finalized bool, sequence int64) error
+
+	// OnOrderChanged signals that orders have changed (placed, filled, or status
+	// update). Consumers should re-fetch via WalletBridge.
+	OnOrderChanged() error
+
+	// OnBalanceChanged signals that the combined value of all assets has changed.
+	// Consumers should re-fetch via WalletBridge.GetBalanceJSON("balance", ...).
+	OnBalanceChanged() error
+
+	// OnBuyingPowerChanged signals that the cash available for new orders has
+	// changed. Consumers should re-fetch via WalletBridge.GetBalanceJSON(
+	// "buying_power", ...).
+	OnBuyingPowerChanged() error
+
+	// OnAssetsChanged signals that the set or quantity of held assets has
+	// changed. Consumers should re-fetch via WalletBridge.GetAssetsJSON.
+	OnAssetsChanged() error
 }
 
 // TradingProviderInfo contains metadata about a trading provider.
@@ -437,6 +454,27 @@ func (t *TradingEngine) createCallbacks() engine.LiveTradingCallbacks {
 		return t.helper.OnLiveDataChanged(runID, &StringArray{items: items}, finalized, sequence)
 	})
 	callbacks.OnLiveDataChanged = &onLiveDataChanged
+
+	// Wallet change callbacks
+	onOrderChanged := engine.OnOrderChangedCallback(func() error {
+		return t.helper.OnOrderChanged()
+	})
+	callbacks.OnOrderChanged = &onOrderChanged
+
+	onBalanceChanged := engine.OnBalanceChangedCallback(func() error {
+		return t.helper.OnBalanceChanged()
+	})
+	callbacks.OnBalanceChanged = &onBalanceChanged
+
+	onBuyingPowerChanged := engine.OnBuyingPowerChangedCallback(func() error {
+		return t.helper.OnBuyingPowerChanged()
+	})
+	callbacks.OnBuyingPowerChanged = &onBuyingPowerChanged
+
+	onAssetsChanged := engine.OnAssetsChangedCallback(func() error {
+		return t.helper.OnAssetsChanged()
+	})
+	callbacks.OnAssetsChanged = &onAssetsChanged
 
 	return callbacks
 }

--- a/pkg/swift-argo/trading_test.go
+++ b/pkg/swift-argo/trading_test.go
@@ -37,6 +37,10 @@ type mockTradingHelper struct {
 	lastDataChangedCats   []string
 	lastDataChangedFinal  bool
 	lastDataChangedSeq    int64
+	orderChangedCalls     int
+	balanceChangedCalls   int
+	buyingPowerCalls      int
+	assetsChangedCalls    int
 	lastSymbols           []string
 	lastInterval          string
 	lastPreviousDataPath  string
@@ -133,6 +137,34 @@ func (m *mockTradingHelper) OnLiveDataChanged(runId string, categories StringCol
 	}
 	m.lastDataChangedFinal = finalized
 	m.lastDataChangedSeq = sequence
+	return nil
+}
+
+func (m *mockTradingHelper) OnOrderChanged() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.orderChangedCalls++
+	return nil
+}
+
+func (m *mockTradingHelper) OnBalanceChanged() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.balanceChangedCalls++
+	return nil
+}
+
+func (m *mockTradingHelper) OnBuyingPowerChanged() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.buyingPowerCalls++
+	return nil
+}
+
+func (m *mockTradingHelper) OnAssetsChanged() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.assetsChangedCalls++
 	return nil
 }
 

--- a/pkg/swift-argo/wallet.go
+++ b/pkg/swift-argo/wallet.go
@@ -1,0 +1,95 @@
+package swiftargo
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/rxtech-lab/argo-trading/internal/trading/wallet"
+	"github.com/rxtech-lab/argo-trading/internal/types"
+)
+
+// WalletBridge is the gomobile-friendly facade over the engine's wallet API.
+// All methods return JSON strings because gomobile cannot return slices or
+// struct values directly.
+type WalletBridge struct {
+	wallet wallet.Wallet
+}
+
+// Wallet returns a WalletBridge for the engine's currently configured trading
+// provider. SetTradingProvider must have been called first; otherwise an error
+// is returned. The bridge is safe to use both inside and outside Run().
+func (t *TradingEngine) Wallet() (*WalletBridge, error) {
+	w, err := t.engine.Wallet()
+	if err != nil {
+		return nil, err
+	}
+
+	return &WalletBridge{wallet: w}, nil
+}
+
+// GetBalanceJSON returns the JSON-encoded types.Balance.
+//
+//   - balanceType: "buying_power" or "balance".
+//   - baseCurrency: ISO code (e.g. "USD"). Pass "" for the default (USD).
+func (w *WalletBridge) GetBalanceJSON(balanceType string, baseCurrency string) (string, error) {
+	balance, err := w.wallet.GetBalance(types.BalanceType(balanceType), baseCurrency)
+	if err != nil {
+		return "", err
+	}
+
+	out, err := json.Marshal(balance)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal balance: %w", err)
+	}
+
+	return string(out), nil
+}
+
+// GetAssetsJSON returns the JSON-encoded []types.Asset. When baseCurrency is
+// non-empty each asset is populated with its value in that currency (nil when
+// no price is available).
+func (w *WalletBridge) GetAssetsJSON(baseCurrency string) (string, error) {
+	assets, err := w.wallet.GetAssets(baseCurrency)
+	if err != nil {
+		return "", err
+	}
+
+	out, err := json.Marshal(assets)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal assets: %w", err)
+	}
+
+	return string(out), nil
+}
+
+// GetHistoricalOrdersJSON returns the JSON-encoded []types.Trade for orders
+// matching filterJSON. filterJSON must conform to types.TradeFilter. Pass "{}"
+// for an unfiltered query (subject to broker-specific requirements — e.g.
+// Binance requires a symbol).
+func (w *WalletBridge) GetHistoricalOrdersJSON(filterJSON string) (string, error) {
+	var filter types.TradeFilter
+
+	if filterJSON != "" {
+		if err := json.Unmarshal([]byte(filterJSON), &filter); err != nil {
+			return "", fmt.Errorf("failed to parse trade filter: %w", err)
+		}
+	}
+
+	trades, err := w.wallet.GetHistoricalOrders(filter)
+	if err != nil {
+		return "", err
+	}
+
+	out, err := json.Marshal(trades)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal trades: %w", err)
+	}
+
+	return string(out), nil
+}
+
+// GetSupportedBaseCurrencies returns the list of base currencies accepted by
+// GetBalance/GetAssets. Today this is just USD.
+func GetSupportedBaseCurrencies() StringCollection {
+	return &StringArray{items: []string{wallet.BaseCurrencyUSD}}
+}


### PR DESCRIPTION
## Summary

Adds a reusable, portable Claude skill at `.claude/skills/docs-publishing/`, distilled from this repo's existing docs CI (`.github/workflows/upload-docs.yaml` + `scripts/upload_docs.py`). It teaches an agent to set up token-authenticated docs publishing for **any** repository.

## Contents

- **`SKILL.md`** — self-contained, copy-pasteable runbook:
  - Author docs under `docs/` as markdown with frontmatter `slug` (unique → remote `docId`), `title`, `description`.
  - Generate each doc TYPE into `docs/`: handwritten design/architecture, OpenAPI/Swagger, and per-language code docs (Go `gomarkdoc`, TS/JS TypeDoc/JSDoc, Java Javadoc).
  - Install the uploader script + workflow.
  - Provision the token via `gh secret set DOCS_UPLOAD_TOKEN` (token from github-pm `POST /api/v1/docs/repositories/[id]/upload-tokens`).
  - Verify via `--dry-run` then `workflow_dispatch`.
- **`templates/upload_docs.py`** — stdlib uploader, verbatim from `scripts/upload_docs.py` (env-driven, `--dry-run`, batch 50, Bearer auth, `POST {endpoint}/api/v1/docs/repositories/{urlencoded repo}/documents`).
- **`templates/upload-docs.yaml`** — workflow: push-to-`main` with `paths` filter + `workflow_dispatch` + `concurrency(cancel-in-progress:false)`.

## Verification

Ran the templated uploader against this repo's real `docs/` with `--dry-run`: parses all 23 documents, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)